### PR TITLE
Update build tasks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,6 @@ alpha:
 	@$(TOOLS) version --bump patch --prerelease alpha && \
 	git add version.go && \
 	git commit -m "Bump version"
-	@$(GO_INSTALL) . ./tools
 
 build: fmtcheck
 	$(GO_BUILD) ./...
@@ -49,7 +48,6 @@ release: build
 	git add version.go && \
 	git commit -m "Cut release $${NEW_VERSION}" && \
 	git tag $${NEW_VERSION}
-	@$(GO_INSTALL) . ./tools
 
 test: fmtcheck
 	@$(GO_TEST) $(PACKAGE_LIST) -timeout=30s -parallel=4

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,59 @@
+GO_CMD=go
+GO_BUILD=$(GO_CMD) build
+GO_DEPS=$(GO_CMD) get -d -v
+GO_FMT=gofmt
+GO_INSTALL=$(GO_CMD) install
+GO_TEST=$(GO_CMD) test
 
-all: fmtcheck
-	go build github.com/softlayer/softlayer-go/...
+PACKAGE_LIST := $$(go list ./... | grep -v '/vendor/')
+
+.PHONY: all build deps fmt fmtcheck generate install install_tools release test update_version
+
+all: build
+
+build: fmtcheck
+	$(GO_BUILD) ./...
+
+deps:
+	@for p in $(PACKAGE_LIST); do \
+		echo "==> Install dependencies for $$p ..."; \
+		$(GO_DEPS) $$p || exit 1; \
+	done
 
 fmt:
-	gofmt -w `find . -name '*.go' | grep -v vendor`
+	@$(GO_FMT) -w `find . -name '*.go' | grep -v vendor`
 
 fmtcheck:
-	@[ -z $$(gofmt -e -l `find . -name '*.go' | grep -v vendor`) ] || \
-		(echo "run 'make fmt'" && false)
+	@fmt_list=$$($(GO_FMT) -e -l `find . -name '*.go' | grep -v vendor`) && \
+	[ -z $${fmt_list} ] || \
+		(echo "gofmt needs to be run on the following files:" \
+			&& echo "$${fmt_list}" && \
+			echo "You can run 'make fmt' to format code" && false)
+
+generate: install_tools
+	@tools generate
+
+install: fmtcheck
+	@$(GO_INSTALL) ./...
+
+install_tools: fmtcheck
+	@$(GO_INSTALL) . ./tools
+
+release: build install_tools
+	@NEW_VERSION=$$(tools version --bump patch) && \
+	git add version.go && \
+	git commit -m "Cut release $${NEW_VERSION}" && \
+	git tag $${NEW_VERSION}
+	@$(GO_INSTALL) . ./tools
+
+test: fmtcheck
+	@$(GO_TEST) $(PACKAGE_LIST) -timeout=30s -parallel=4
+
+update_version: install_tools
+	@tools version --bump patch --prerelease alpha && \
+	git add version.go && \
+    git commit -m "Bump version"
+	@$(GO_INSTALL) . ./tools
+
+version: install_tools
+	@tools version

--- a/Makefile
+++ b/Makefile
@@ -7,9 +7,15 @@ GO_TEST=$(GO_CMD) test
 
 PACKAGE_LIST := $$(go list ./... | grep -v '/vendor/')
 
-.PHONY: all build deps fmt fmtcheck generate install install_tools release test update_version
+.PHONY: all alpha build deps fmt fmtcheck generate install install_tools release test
 
 all: build
+
+alpha:
+	@$(TOOLS) version --bump patch --prerelease alpha && \
+	git add version.go && \
+	git commit -m "Bump version"
+	@$(GO_INSTALL) . ./tools
 
 build: fmtcheck
 	$(GO_BUILD) ./...
@@ -48,12 +54,6 @@ release: build install_tools
 
 test: fmtcheck
 	@$(GO_TEST) $(PACKAGE_LIST) -timeout=30s -parallel=4
-
-update_version: install_tools
-	@tools version --bump patch --prerelease alpha && \
-	git add version.go && \
-    git commit -m "Bump version"
-	@$(GO_INSTALL) . ./tools
 
 version: install_tools
 	@tools version

--- a/Makefile
+++ b/Makefile
@@ -3,11 +3,13 @@ GO_BUILD=$(GO_CMD) build
 GO_DEPS=$(GO_CMD) get -d -v
 GO_FMT=gofmt
 GO_INSTALL=$(GO_CMD) install
+GO_RUN=$(GO_CMD) run
 GO_TEST=$(GO_CMD) test
+TOOLS=$(GO_RUN) tools/*.go
 
 PACKAGE_LIST := $$(go list ./... | grep -v '/vendor/')
 
-.PHONY: all alpha build deps fmt fmtcheck generate install install_tools release test
+.PHONY: all alpha build deps fmt fmtcheck generate install release test
 
 all: build
 
@@ -36,17 +38,14 @@ fmtcheck:
 			&& echo "$${fmt_list}" && \
 			echo "You can run 'make fmt' to format code" && false)
 
-generate: install_tools
-	@tools generate
+generate:
+	@$(TOOLS) generate
 
 install: fmtcheck
 	@$(GO_INSTALL) ./...
 
-install_tools: fmtcheck
-	@$(GO_INSTALL) . ./tools
-
-release: build install_tools
-	@NEW_VERSION=$$(tools version --bump patch) && \
+release: build
+	@NEW_VERSION=$$($(TOOLS) version --bump patch) && \
 	git add version.go && \
 	git commit -m "Cut release $${NEW_VERSION}" && \
 	git tag $${NEW_VERSION}
@@ -55,5 +54,5 @@ release: build install_tools
 test: fmtcheck
 	@$(GO_TEST) $(PACKAGE_LIST) -timeout=30s -parallel=4
 
-version: install_tools
-	@tools version
+version:
+	@$(TOOLS) version

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ all: build
 
 alpha:
 	@$(TOOLS) version --bump patch --prerelease alpha && \
-	git add version.go && \
+	git add sl/version.go && \
 	git commit -m "Bump version"
 
 build: fmtcheck
@@ -45,7 +45,7 @@ install: fmtcheck
 
 release: build
 	@NEW_VERSION=$$($(TOOLS) version --bump patch) && \
-	git add version.go && \
+	git add sl/version.go && \
 	git commit -m "Cut release $${NEW_VERSION}" && \
 	git tag $${NEW_VERSION}
 

--- a/sl/version.go
+++ b/sl/version.go
@@ -18,7 +18,7 @@
  * AUTOMATICALLY GENERATED CODE - DO NOT MODIFY
  */
 
-package softlayer_go
+package sl
 
 import "fmt"
 
@@ -32,7 +32,7 @@ type VersionInfo struct {
 var Version = VersionInfo{
 	Major: 0,
 	Minor: 1,
-	Patch: 0,
+	Patch: 4,
 	Pre:   "",
 }
 

--- a/tools/common.go
+++ b/tools/common.go
@@ -1,0 +1,48 @@
+/**
+ * Copyright 2016 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+const license = `/**
+ * Copyright 2016 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ `
+
+const codegenWarning = `/**
+ * AUTOMATICALLY GENERATED CODE - DO NOT MODIFY
+ */`
+
+func bail(err error) {
+	fmt.Println(err)
+	os.Exit(1)
+}

--- a/tools/loadmeta.go
+++ b/tools/loadmeta.go
@@ -82,27 +82,6 @@ var fMap = template.FuncMap{
 	"phraseMethodArg": phraseMethodArg,     // Get proper phrase for method argument
 }
 
-const license = `/**
- * Copyright 2016 IBM Corp.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
- `
-
-const codegenWarning = `/**
- * AUTOMATICALLY GENERATED CODE - DO NOT MODIFY
- */`
-
 var datatype = fmt.Sprintf(`%s
 
 %s
@@ -192,11 +171,12 @@ import (
 {{end}}
 `, license, codegenWarning)
 
-func main() {
+func generateAPI() {
 	var meta map[string]Type
 
+	flagset := flag.NewFlagSet(os.Args[1], flag.ExitOnError)
 	outputPath := flag.String("o", ".", "the root of the go project to be refreshed")
-	flag.Parse()
+	flagset.Parse(os.Args[2:])
 
 	jsonResp, code, err := makeHttpRequest("https://api.softlayer.com/metadata/v3.1", "GET", new(bytes.Buffer))
 

--- a/tools/main.go
+++ b/tools/main.go
@@ -1,0 +1,49 @@
+/**
+ * Copyright 2016 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+const usage = `Usage: tools <cmd> [options]
+
+Commands:
+
+	generate: Generate the SDK from the API metadata
+
+	version: library version management
+`
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println(usage)
+		os.Exit(1)
+	}
+
+	switch os.Args[1] {
+	case "generate":
+		generateAPI()
+	case "version":
+		version()
+	default:
+		fmt.Println("Unrecognized command")
+		os.Exit(1)
+	}
+
+}

--- a/tools/version.go
+++ b/tools/version.go
@@ -107,7 +107,7 @@ func version() {
 func writeVersionFile(v sl.VersionInfo) {
 	// Generate source
 	var buf bytes.Buffer
-	t := template.New("test")
+	t := template.New("version")
 	template.Must(t.Parse(versionfile)).Execute(&buf, v)
 
 	//fmt.Println(string(buf.Bytes()))

--- a/tools/version.go
+++ b/tools/version.go
@@ -24,14 +24,14 @@ import (
 	"os"
 
 	"flag"
-	"github.com/softlayer/softlayer-go"
+	"github.com/softlayer/softlayer-go/sl"
 )
 
 var versionfile = fmt.Sprintf(`%s
 
 %s
 
-package softlayer_go
+package sl
 
 import "fmt"
 
@@ -79,7 +79,7 @@ func version() {
 
 	flagset.Parse(os.Args[2:])
 
-	v := softlayer_go.Version
+	v := sl.Version
 
 	switch bump {
 	case "major":
@@ -104,7 +104,7 @@ func version() {
 	fmt.Println(v)
 }
 
-func writeVersionFile(v softlayer_go.VersionInfo) {
+func writeVersionFile(v sl.VersionInfo) {
 	// Generate source
 	var buf bytes.Buffer
 	t := template.New("test")
@@ -120,7 +120,7 @@ func writeVersionFile(v softlayer_go.VersionInfo) {
 	}
 
 	// write go file
-	f, err := os.Create("./version.go")
+	f, err := os.Create("sl/version.go")
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)

--- a/tools/version.go
+++ b/tools/version.go
@@ -1,0 +1,130 @@
+/**
+ * Copyright 2016 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"go/format"
+	"html/template"
+	"os"
+
+	"flag"
+	"github.com/softlayer/softlayer-go"
+)
+
+var versionfile = fmt.Sprintf(`%s
+
+%s
+
+package softlayer_go
+
+import "fmt"
+
+type VersionInfo struct {
+	Major  int
+	Minor  int
+	Patch  int
+	Pre    string
+}
+
+var Version = VersionInfo {
+	Major:  {{.Major}},
+	Minor:  {{.Minor}},
+	Patch:  {{.Patch}},
+	Pre:    "{{.Pre}}",
+}
+
+func (v VersionInfo) String() string {
+	result := fmt.Sprintf("v%%d.%%d.%%d", v.Major, v.Minor, v.Patch)
+
+	if v.Pre != "" {
+		result += fmt.Sprintf("-%%s", v.Pre)
+	}
+
+	return result
+}
+
+`, license, codegenWarning)
+
+const (
+	bumpUsage   = "specify one of major|minor|patch to bump that specifier"
+	prerelUsage = "optional prerelease stamp (e.g. alpha, beta, rc.1"
+)
+
+func version() {
+	var bump, prerelease string
+
+	flagset := flag.NewFlagSet(os.Args[1], flag.ExitOnError)
+
+	flagset.StringVar(&bump, "bump", "", bumpUsage)
+	flagset.StringVar(&bump, "b", "", bumpUsage+" (shorthand)")
+
+	flagset.StringVar(&prerelease, "prerelease", "", prerelUsage)
+	flagset.StringVar(&prerelease, "p", "", prerelUsage+" (shorthand)")
+
+	flagset.Parse(os.Args[2:])
+
+	v := softlayer_go.Version
+
+	switch bump {
+	case "major":
+		v.Major++
+		v.Minor = 0
+		v.Patch = 0
+		v.Pre = prerelease
+	case "minor":
+		v.Minor++
+		v.Patch = 0
+		v.Pre = prerelease
+	case "patch":
+		v.Patch++
+		v.Pre = prerelease
+	case "":
+	default:
+		bail(fmt.Errorf("Invalid value for bump: %s", bump))
+	}
+
+	writeVersionFile(v)
+
+	fmt.Println(v)
+}
+
+func writeVersionFile(v softlayer_go.VersionInfo) {
+	// Generate source
+	var buf bytes.Buffer
+	t := template.New("test")
+	template.Must(t.Parse(versionfile)).Execute(&buf, v)
+
+	//fmt.Println(string(buf.Bytes()))
+
+	// format go file
+	pretty, err := format.Source(buf.Bytes())
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	// write go file
+	f, err := os.Create("./version.go")
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	defer f.Close()
+	fmt.Fprintf(f, "%s", pretty)
+}

--- a/version.go
+++ b/version.go
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2016 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * AUTOMATICALLY GENERATED CODE - DO NOT MODIFY
+ */
+
+package softlayer_go
+
+import "fmt"
+
+type VersionInfo struct {
+	Major int
+	Minor int
+	Patch int
+	Pre   string
+}
+
+var Version = VersionInfo{
+	Major: 0,
+	Minor: 1,
+	Patch: 0,
+	Pre:   "",
+}
+
+func (v VersionInfo) String() string {
+	result := fmt.Sprintf("v%d.%d.%d", v.Major, v.Minor, v.Patch)
+
+	if v.Pre != "" {
+		result += fmt.Sprintf("-%s", v.Pre)
+	}
+
+	return result
+}


### PR DESCRIPTION
Makefile Updates
-----------------
Added the following `make` goals:

_deps_ - installs package dependencies
_generate_ - generates SDK code from API metadata
_install_ - `go install ./...`
_install_tools_ - `go install . ./tools` (prereq for other goals that require "tools" - more info below)
_release_ - bumps the patch level, removes any prerelease identifier, commits the version file, and tags the revision (stops short of push at this time)
_test_ - runs the testcases for all packages
_update_version_ - bumps the patch level and adds the prerelease identifier 'alpha', commits the version file.
_version_ - Prints the current version

Fixed an issue with the `fmtcheck` task where multiple files in need of formatting causes a bash error.

Tools
-----
Added a `tools` package with a basic cli (`tools <cmd> [options]`)
Moved loadmeta.go under `tools` (`tools generate` - used by `make generate`)
Added version tool (`tools version [--bump major|minor|patch] [--prerelease <identifier>]`).  Used by the release, update_version, and version `make` tasks.

Versioning
----------
There is now a generated `version.go` file in the base package.  Version can be managed from the `make` goals `update_version` and `release`.

```bash
# bump the patch level
$ make update_version

# tag a release
$ make release
```


To get a version string from an API client:

```go
import (
    "fmt"
    "github.com/softlayer/softlayer-go"
)

fmt.Println(softlayer_go.Version)
```