### PR TITLE
Only build filters up to map[string]interface{}

### DIFF
--- a/filter/filters.go
+++ b/filter/filters.go
@@ -19,7 +19,6 @@
 package filter
 
 import (
-	"encoding/json"
 	"fmt"
 	"strings"
 )
@@ -40,7 +39,7 @@ func New(args ...Filter) Filters {
 
 // This is like calling New().Build().
 // Returns a JSON string that can be used as the object filter.
-func Build(args ...Filter) string {
+func Build(args ...Filter) map[string]interface{} {
 	filters := Filters{}
 
 	for _, arg := range args {
@@ -62,7 +61,7 @@ func Path(path string, val ...interface{}) Filter {
 }
 
 // Builds the filter string in JSON format
-func (fs Filters) Build() string {
+func (fs Filters) Build() map[string]interface{} {
 	// Loops around filters,
 	// splitting path on '.' and looping around path pieces.
 	// Idea is to create a map/tree like map[string]interface{}.
@@ -127,12 +126,11 @@ func (fs Filters) Build() string {
 		}
 	}
 
-	jsonStr, _ := json.Marshal(result)
-	return string(jsonStr)
+	return result
 }
 
 // Builds the filter string in JSON format
-func (f Filter) Build() string {
+func (f Filter) Build() map[string]interface{} {
 	return Build(f)
 }
 

--- a/services/account.go
+++ b/services/account.go
@@ -55,7 +55,7 @@ func (r Account) Mask(mask string) Account {
 	return r
 }
 
-func (r Account) Filter(filter string) Account {
+func (r Account) Filter(filter interface{}) Account {
 	r.Options.Filter = filter
 	return r
 }
@@ -2025,7 +2025,7 @@ func (r Account_Address) Mask(mask string) Account_Address {
 	return r
 }
 
-func (r Account_Address) Filter(filter string) Account_Address {
+func (r Account_Address) Filter(filter interface{}) Account_Address {
 	r.Options.Filter = filter
 	return r
 }
@@ -2139,7 +2139,7 @@ func (r Account_Address_Type) Mask(mask string) Account_Address_Type {
 	return r
 }
 
-func (r Account_Address_Type) Filter(filter string) Account_Address_Type {
+func (r Account_Address_Type) Filter(filter interface{}) Account_Address_Type {
 	r.Options.Filter = filter
 	return r
 }
@@ -2184,7 +2184,7 @@ func (r Account_Affiliation) Mask(mask string) Account_Affiliation {
 	return r
 }
 
-func (r Account_Affiliation) Filter(filter string) Account_Affiliation {
+func (r Account_Affiliation) Filter(filter interface{}) Account_Affiliation {
 	r.Options.Filter = filter
 	return r
 }
@@ -2268,7 +2268,7 @@ func (r Account_Agreement) Mask(mask string) Account_Agreement {
 	return r
 }
 
-func (r Account_Agreement) Filter(filter string) Account_Agreement {
+func (r Account_Agreement) Filter(filter interface{}) Account_Agreement {
 	r.Options.Filter = filter
 	return r
 }
@@ -2349,7 +2349,7 @@ func (r Account_Authentication_Attribute) Mask(mask string) Account_Authenticati
 	return r
 }
 
-func (r Account_Authentication_Attribute) Filter(filter string) Account_Authentication_Attribute {
+func (r Account_Authentication_Attribute) Filter(filter interface{}) Account_Authentication_Attribute {
 	r.Options.Filter = filter
 	return r
 }
@@ -2412,7 +2412,7 @@ func (r Account_Authentication_Attribute_Type) Mask(mask string) Account_Authent
 	return r
 }
 
-func (r Account_Authentication_Attribute_Type) Filter(filter string) Account_Authentication_Attribute_Type {
+func (r Account_Authentication_Attribute_Type) Filter(filter interface{}) Account_Authentication_Attribute_Type {
 	r.Options.Filter = filter
 	return r
 }
@@ -2463,7 +2463,7 @@ func (r Account_Authentication_Saml) Mask(mask string) Account_Authentication_Sa
 	return r
 }
 
-func (r Account_Authentication_Saml) Filter(filter string) Account_Authentication_Saml {
+func (r Account_Authentication_Saml) Filter(filter interface{}) Account_Authentication_Saml {
 	r.Options.Filter = filter
 	return r
 }
@@ -2550,7 +2550,7 @@ func (r Account_Contact) Mask(mask string) Account_Contact {
 	return r
 }
 
-func (r Account_Contact) Filter(filter string) Account_Contact {
+func (r Account_Contact) Filter(filter interface{}) Account_Contact {
 	r.Options.Filter = filter
 	return r
 }
@@ -2637,7 +2637,7 @@ func (r Account_Historical_Report) Mask(mask string) Account_Historical_Report {
 	return r
 }
 
-func (r Account_Historical_Report) Filter(filter string) Account_Historical_Report {
+func (r Account_Historical_Report) Filter(filter interface{}) Account_Historical_Report {
 	r.Options.Filter = filter
 	return r
 }
@@ -2760,7 +2760,7 @@ func (r Account_Link_Bluemix) Mask(mask string) Account_Link_Bluemix {
 	return r
 }
 
-func (r Account_Link_Bluemix) Filter(filter string) Account_Link_Bluemix {
+func (r Account_Link_Bluemix) Filter(filter interface{}) Account_Link_Bluemix {
 	r.Options.Filter = filter
 	return r
 }
@@ -2811,7 +2811,7 @@ func (r Account_Link_OpenStack) Mask(mask string) Account_Link_OpenStack {
 	return r
 }
 
-func (r Account_Link_OpenStack) Filter(filter string) Account_Link_OpenStack {
+func (r Account_Link_OpenStack) Filter(filter interface{}) Account_Link_OpenStack {
 	r.Options.Filter = filter
 	return r
 }
@@ -2913,7 +2913,7 @@ func (r Account_Lockdown_Request) Mask(mask string) Account_Lockdown_Request {
 	return r
 }
 
-func (r Account_Lockdown_Request) Filter(filter string) Account_Lockdown_Request {
+func (r Account_Lockdown_Request) Filter(filter interface{}) Account_Lockdown_Request {
 	r.Options.Filter = filter
 	return r
 }
@@ -3002,7 +3002,7 @@ func (r Account_MasterServiceAgreement) Mask(mask string) Account_MasterServiceA
 	return r
 }
 
-func (r Account_MasterServiceAgreement) Filter(filter string) Account_MasterServiceAgreement {
+func (r Account_MasterServiceAgreement) Filter(filter interface{}) Account_MasterServiceAgreement {
 	r.Options.Filter = filter
 	return r
 }
@@ -3059,7 +3059,7 @@ func (r Account_Media) Mask(mask string) Account_Media {
 	return r
 }
 
-func (r Account_Media) Filter(filter string) Account_Media {
+func (r Account_Media) Filter(filter interface{}) Account_Media {
 	r.Options.Filter = filter
 	return r
 }
@@ -3176,7 +3176,7 @@ func (r Account_Media_Data_Transfer_Request) Mask(mask string) Account_Media_Dat
 	return r
 }
 
-func (r Account_Media_Data_Transfer_Request) Filter(filter string) Account_Media_Data_Transfer_Request {
+func (r Account_Media_Data_Transfer_Request) Filter(filter interface{}) Account_Media_Data_Transfer_Request {
 	r.Options.Filter = filter
 	return r
 }
@@ -3296,7 +3296,7 @@ func (r Account_Note) Mask(mask string) Account_Note {
 	return r
 }
 
-func (r Account_Note) Filter(filter string) Account_Note {
+func (r Account_Note) Filter(filter interface{}) Account_Note {
 	r.Options.Filter = filter
 	return r
 }
@@ -3389,7 +3389,7 @@ func (r Account_Note_Type) Mask(mask string) Account_Note_Type {
 	return r
 }
 
-func (r Account_Note_Type) Filter(filter string) Account_Note_Type {
+func (r Account_Note_Type) Filter(filter interface{}) Account_Note_Type {
 	r.Options.Filter = filter
 	return r
 }
@@ -3464,7 +3464,7 @@ func (r Account_Partner_Referral_Prospect) Mask(mask string) Account_Partner_Ref
 	return r
 }
 
-func (r Account_Partner_Referral_Prospect) Filter(filter string) Account_Partner_Referral_Prospect {
+func (r Account_Partner_Referral_Prospect) Filter(filter interface{}) Account_Partner_Referral_Prospect {
 	r.Options.Filter = filter
 	return r
 }
@@ -3525,7 +3525,7 @@ func (r Account_Password) Mask(mask string) Account_Password {
 	return r
 }
 
-func (r Account_Password) Filter(filter string) Account_Password {
+func (r Account_Password) Filter(filter interface{}) Account_Password {
 	r.Options.Filter = filter
 	return r
 }
@@ -3595,7 +3595,7 @@ func (r Account_Regional_Registry_Detail) Mask(mask string) Account_Regional_Reg
 	return r
 }
 
-func (r Account_Regional_Registry_Detail) Filter(filter string) Account_Regional_Registry_Detail {
+func (r Account_Regional_Registry_Detail) Filter(filter interface{}) Account_Regional_Registry_Detail {
 	r.Options.Filter = filter
 	return r
 }
@@ -3702,7 +3702,7 @@ func (r Account_Regional_Registry_Detail_Property) Mask(mask string) Account_Reg
 	return r
 }
 
-func (r Account_Regional_Registry_Detail_Property) Filter(filter string) Account_Regional_Registry_Detail_Property {
+func (r Account_Regional_Registry_Detail_Property) Filter(filter interface{}) Account_Regional_Registry_Detail_Property {
 	r.Options.Filter = filter
 	return r
 }
@@ -3803,7 +3803,7 @@ func (r Account_Regional_Registry_Detail_Property_Type) Mask(mask string) Accoun
 	return r
 }
 
-func (r Account_Regional_Registry_Detail_Property_Type) Filter(filter string) Account_Regional_Registry_Detail_Property_Type {
+func (r Account_Regional_Registry_Detail_Property_Type) Filter(filter interface{}) Account_Regional_Registry_Detail_Property_Type {
 	r.Options.Filter = filter
 	return r
 }
@@ -3856,7 +3856,7 @@ func (r Account_Regional_Registry_Detail_Type) Mask(mask string) Account_Regiona
 	return r
 }
 
-func (r Account_Regional_Registry_Detail_Type) Filter(filter string) Account_Regional_Registry_Detail_Type {
+func (r Account_Regional_Registry_Detail_Type) Filter(filter interface{}) Account_Regional_Registry_Detail_Type {
 	r.Options.Filter = filter
 	return r
 }
@@ -3907,7 +3907,7 @@ func (r Account_Reports_Request) Mask(mask string) Account_Reports_Request {
 	return r
 }
 
-func (r Account_Reports_Request) Filter(filter string) Account_Reports_Request {
+func (r Account_Reports_Request) Filter(filter interface{}) Account_Reports_Request {
 	r.Options.Filter = filter
 	return r
 }
@@ -4026,7 +4026,7 @@ func (r Account_Shipment) Mask(mask string) Account_Shipment {
 	return r
 }
 
-func (r Account_Shipment) Filter(filter string) Account_Shipment {
+func (r Account_Shipment) Filter(filter interface{}) Account_Shipment {
 	r.Options.Filter = filter
 	return r
 }
@@ -4179,7 +4179,7 @@ func (r Account_Shipment_Item) Mask(mask string) Account_Shipment_Item {
 	return r
 }
 
-func (r Account_Shipment_Item) Filter(filter string) Account_Shipment_Item {
+func (r Account_Shipment_Item) Filter(filter interface{}) Account_Shipment_Item {
 	r.Options.Filter = filter
 	return r
 }
@@ -4245,7 +4245,7 @@ func (r Account_Shipment_Item_Type) Mask(mask string) Account_Shipment_Item_Type
 	return r
 }
 
-func (r Account_Shipment_Item_Type) Filter(filter string) Account_Shipment_Item_Type {
+func (r Account_Shipment_Item_Type) Filter(filter interface{}) Account_Shipment_Item_Type {
 	r.Options.Filter = filter
 	return r
 }
@@ -4290,7 +4290,7 @@ func (r Account_Shipment_Resource_Type) Mask(mask string) Account_Shipment_Resou
 	return r
 }
 
-func (r Account_Shipment_Resource_Type) Filter(filter string) Account_Shipment_Resource_Type {
+func (r Account_Shipment_Resource_Type) Filter(filter interface{}) Account_Shipment_Resource_Type {
 	r.Options.Filter = filter
 	return r
 }
@@ -4335,7 +4335,7 @@ func (r Account_Shipment_Status) Mask(mask string) Account_Shipment_Status {
 	return r
 }
 
-func (r Account_Shipment_Status) Filter(filter string) Account_Shipment_Status {
+func (r Account_Shipment_Status) Filter(filter interface{}) Account_Shipment_Status {
 	r.Options.Filter = filter
 	return r
 }
@@ -4380,7 +4380,7 @@ func (r Account_Shipment_Tracking_Data) Mask(mask string) Account_Shipment_Track
 	return r
 }
 
-func (r Account_Shipment_Tracking_Data) Filter(filter string) Account_Shipment_Tracking_Data {
+func (r Account_Shipment_Tracking_Data) Filter(filter interface{}) Account_Shipment_Tracking_Data {
 	r.Options.Filter = filter
 	return r
 }
@@ -4488,7 +4488,7 @@ func (r Account_Shipment_Type) Mask(mask string) Account_Shipment_Type {
 	return r
 }
 
-func (r Account_Shipment_Type) Filter(filter string) Account_Shipment_Type {
+func (r Account_Shipment_Type) Filter(filter interface{}) Account_Shipment_Type {
 	r.Options.Filter = filter
 	return r
 }

--- a/services/auxiliary.go
+++ b/services/auxiliary.go
@@ -53,7 +53,7 @@ func (r Auxiliary_Marketing_Event) Mask(mask string) Auxiliary_Marketing_Event {
 	return r
 }
 
-func (r Auxiliary_Marketing_Event) Filter(filter string) Auxiliary_Marketing_Event {
+func (r Auxiliary_Marketing_Event) Filter(filter interface{}) Auxiliary_Marketing_Event {
 	r.Options.Filter = filter
 	return r
 }
@@ -104,7 +104,7 @@ func (r Auxiliary_Network_Status) Mask(mask string) Auxiliary_Network_Status {
 	return r
 }
 
-func (r Auxiliary_Network_Status) Filter(filter string) Auxiliary_Network_Status {
+func (r Auxiliary_Network_Status) Filter(filter interface{}) Auxiliary_Network_Status {
 	r.Options.Filter = filter
 	return r
 }
@@ -163,7 +163,7 @@ func (r Auxiliary_Notification_Emergency) Mask(mask string) Auxiliary_Notificati
 	return r
 }
 
-func (r Auxiliary_Notification_Emergency) Filter(filter string) Auxiliary_Notification_Emergency {
+func (r Auxiliary_Notification_Emergency) Filter(filter interface{}) Auxiliary_Notification_Emergency {
 	r.Options.Filter = filter
 	return r
 }
@@ -232,7 +232,7 @@ func (r Auxiliary_Press_Release) Mask(mask string) Auxiliary_Press_Release {
 	return r
 }
 
-func (r Auxiliary_Press_Release) Filter(filter string) Auxiliary_Press_Release {
+func (r Auxiliary_Press_Release) Filter(filter interface{}) Auxiliary_Press_Release {
 	r.Options.Filter = filter
 	return r
 }
@@ -329,7 +329,7 @@ func (r Auxiliary_Press_Release_About) Mask(mask string) Auxiliary_Press_Release
 	return r
 }
 
-func (r Auxiliary_Press_Release_About) Filter(filter string) Auxiliary_Press_Release_About {
+func (r Auxiliary_Press_Release_About) Filter(filter interface{}) Auxiliary_Press_Release_About {
 	r.Options.Filter = filter
 	return r
 }
@@ -374,7 +374,7 @@ func (r Auxiliary_Press_Release_About_Press_Release) Mask(mask string) Auxiliary
 	return r
 }
 
-func (r Auxiliary_Press_Release_About_Press_Release) Filter(filter string) Auxiliary_Press_Release_About_Press_Release {
+func (r Auxiliary_Press_Release_About_Press_Release) Filter(filter interface{}) Auxiliary_Press_Release_About_Press_Release {
 	r.Options.Filter = filter
 	return r
 }
@@ -431,7 +431,7 @@ func (r Auxiliary_Press_Release_Contact) Mask(mask string) Auxiliary_Press_Relea
 	return r
 }
 
-func (r Auxiliary_Press_Release_Contact) Filter(filter string) Auxiliary_Press_Release_Contact {
+func (r Auxiliary_Press_Release_Contact) Filter(filter interface{}) Auxiliary_Press_Release_Contact {
 	r.Options.Filter = filter
 	return r
 }
@@ -476,7 +476,7 @@ func (r Auxiliary_Press_Release_Contact_Press_Release) Mask(mask string) Auxilia
 	return r
 }
 
-func (r Auxiliary_Press_Release_Contact_Press_Release) Filter(filter string) Auxiliary_Press_Release_Contact_Press_Release {
+func (r Auxiliary_Press_Release_Contact_Press_Release) Filter(filter interface{}) Auxiliary_Press_Release_Contact_Press_Release {
 	r.Options.Filter = filter
 	return r
 }
@@ -533,7 +533,7 @@ func (r Auxiliary_Press_Release_Content) Mask(mask string) Auxiliary_Press_Relea
 	return r
 }
 
-func (r Auxiliary_Press_Release_Content) Filter(filter string) Auxiliary_Press_Release_Content {
+func (r Auxiliary_Press_Release_Content) Filter(filter interface{}) Auxiliary_Press_Release_Content {
 	r.Options.Filter = filter
 	return r
 }
@@ -578,7 +578,7 @@ func (r Auxiliary_Press_Release_Media_Partner) Mask(mask string) Auxiliary_Press
 	return r
 }
 
-func (r Auxiliary_Press_Release_Media_Partner) Filter(filter string) Auxiliary_Press_Release_Media_Partner {
+func (r Auxiliary_Press_Release_Media_Partner) Filter(filter interface{}) Auxiliary_Press_Release_Media_Partner {
 	r.Options.Filter = filter
 	return r
 }
@@ -623,7 +623,7 @@ func (r Auxiliary_Press_Release_Media_Partner_Press_Release) Mask(mask string) A
 	return r
 }
 
-func (r Auxiliary_Press_Release_Media_Partner_Press_Release) Filter(filter string) Auxiliary_Press_Release_Media_Partner_Press_Release {
+func (r Auxiliary_Press_Release_Media_Partner_Press_Release) Filter(filter interface{}) Auxiliary_Press_Release_Media_Partner_Press_Release {
 	r.Options.Filter = filter
 	return r
 }
@@ -680,7 +680,7 @@ func (r Auxiliary_Shipping_Courier_Type) Mask(mask string) Auxiliary_Shipping_Co
 	return r
 }
 
-func (r Auxiliary_Shipping_Courier_Type) Filter(filter string) Auxiliary_Shipping_Courier_Type {
+func (r Auxiliary_Shipping_Courier_Type) Filter(filter interface{}) Auxiliary_Shipping_Courier_Type {
 	r.Options.Filter = filter
 	return r
 }

--- a/services/billing.go
+++ b/services/billing.go
@@ -53,7 +53,7 @@ func (r Billing_Currency) Mask(mask string) Billing_Currency {
 	return r
 }
 
-func (r Billing_Currency) Filter(filter string) Billing_Currency {
+func (r Billing_Currency) Filter(filter interface{}) Billing_Currency {
 	r.Options.Filter = filter
 	return r
 }
@@ -114,7 +114,7 @@ func (r Billing_Currency_ExchangeRate) Mask(mask string) Billing_Currency_Exchan
 	return r
 }
 
-func (r Billing_Currency_ExchangeRate) Filter(filter string) Billing_Currency_ExchangeRate {
+func (r Billing_Currency_ExchangeRate) Filter(filter interface{}) Billing_Currency_ExchangeRate {
 	r.Options.Filter = filter
 	return r
 }
@@ -207,7 +207,7 @@ func (r Billing_Info) Mask(mask string) Billing_Info {
 	return r
 }
 
-func (r Billing_Info) Filter(filter string) Billing_Info {
+func (r Billing_Info) Filter(filter interface{}) Billing_Info {
 	r.Options.Filter = filter
 	return r
 }
@@ -288,7 +288,7 @@ func (r Billing_Invoice) Mask(mask string) Billing_Invoice {
 	return r
 }
 
-func (r Billing_Invoice) Filter(filter string) Billing_Invoice {
+func (r Billing_Invoice) Filter(filter interface{}) Billing_Invoice {
 	r.Options.Filter = filter
 	return r
 }
@@ -523,7 +523,7 @@ func (r Billing_Invoice_Item) Mask(mask string) Billing_Invoice_Item {
 	return r
 }
 
-func (r Billing_Invoice_Item) Filter(filter string) Billing_Invoice_Item {
+func (r Billing_Invoice_Item) Filter(filter interface{}) Billing_Invoice_Item {
 	r.Options.Filter = filter
 	return r
 }
@@ -658,7 +658,7 @@ func (r Billing_Invoice_Next) Mask(mask string) Billing_Invoice_Next {
 	return r
 }
 
-func (r Billing_Invoice_Next) Filter(filter string) Billing_Invoice_Next {
+func (r Billing_Invoice_Next) Filter(filter interface{}) Billing_Invoice_Next {
 	r.Options.Filter = filter
 	return r
 }
@@ -724,7 +724,7 @@ func (r Billing_Invoice_Tax_Status) Mask(mask string) Billing_Invoice_Tax_Status
 	return r
 }
 
-func (r Billing_Invoice_Tax_Status) Filter(filter string) Billing_Invoice_Tax_Status {
+func (r Billing_Invoice_Tax_Status) Filter(filter interface{}) Billing_Invoice_Tax_Status {
 	r.Options.Filter = filter
 	return r
 }
@@ -775,7 +775,7 @@ func (r Billing_Invoice_Tax_Type) Mask(mask string) Billing_Invoice_Tax_Type {
 	return r
 }
 
-func (r Billing_Invoice_Tax_Type) Filter(filter string) Billing_Invoice_Tax_Type {
+func (r Billing_Invoice_Tax_Type) Filter(filter interface{}) Billing_Invoice_Tax_Type {
 	r.Options.Filter = filter
 	return r
 }
@@ -828,7 +828,7 @@ func (r Billing_Item) Mask(mask string) Billing_Item {
 	return r
 }
 
-func (r Billing_Item) Filter(filter string) Billing_Item {
+func (r Billing_Item) Filter(filter interface{}) Billing_Item {
 	r.Options.Filter = filter
 	return r
 }
@@ -1243,7 +1243,7 @@ func (r Billing_Item_Cancellation_Reason) Mask(mask string) Billing_Item_Cancell
 	return r
 }
 
-func (r Billing_Item_Cancellation_Reason) Filter(filter string) Billing_Item_Cancellation_Reason {
+func (r Billing_Item_Cancellation_Reason) Filter(filter interface{}) Billing_Item_Cancellation_Reason {
 	r.Options.Filter = filter
 	return r
 }
@@ -1312,7 +1312,7 @@ func (r Billing_Item_Cancellation_Reason_Category) Mask(mask string) Billing_Ite
 	return r
 }
 
-func (r Billing_Item_Cancellation_Reason_Category) Filter(filter string) Billing_Item_Cancellation_Reason_Category {
+func (r Billing_Item_Cancellation_Reason_Category) Filter(filter interface{}) Billing_Item_Cancellation_Reason_Category {
 	r.Options.Filter = filter
 	return r
 }
@@ -1369,7 +1369,7 @@ func (r Billing_Item_Cancellation_Request) Mask(mask string) Billing_Item_Cancel
 	return r
 }
 
-func (r Billing_Item_Cancellation_Request) Filter(filter string) Billing_Item_Cancellation_Request {
+func (r Billing_Item_Cancellation_Request) Filter(filter interface{}) Billing_Item_Cancellation_Request {
 	r.Options.Filter = filter
 	return r
 }
@@ -1502,7 +1502,7 @@ func (r Billing_Order) Mask(mask string) Billing_Order {
 	return r
 }
 
-func (r Billing_Order) Filter(filter string) Billing_Order {
+func (r Billing_Order) Filter(filter interface{}) Billing_Order {
 	r.Options.Filter = filter
 	return r
 }
@@ -1761,7 +1761,7 @@ func (r Billing_Order_Cart) Mask(mask string) Billing_Order_Cart {
 	return r
 }
 
-func (r Billing_Order_Cart) Filter(filter string) Billing_Order_Cart {
+func (r Billing_Order_Cart) Filter(filter interface{}) Billing_Order_Cart {
 	r.Options.Filter = filter
 	return r
 }
@@ -1943,7 +1943,7 @@ func (r Billing_Order_Item) Mask(mask string) Billing_Order_Item {
 	return r
 }
 
-func (r Billing_Order_Item) Filter(filter string) Billing_Order_Item {
+func (r Billing_Order_Item) Filter(filter interface{}) Billing_Order_Item {
 	r.Options.Filter = filter
 	return r
 }
@@ -2114,7 +2114,7 @@ func (r Billing_Order_Quote) Mask(mask string) Billing_Order_Quote {
 	return r
 }
 
-func (r Billing_Order_Quote) Filter(filter string) Billing_Order_Quote {
+func (r Billing_Order_Quote) Filter(filter interface{}) Billing_Order_Quote {
 	r.Options.Filter = filter
 	return r
 }

--- a/services/brand.go
+++ b/services/brand.go
@@ -55,7 +55,7 @@ func (r Brand) Mask(mask string) Brand {
 	return r
 }
 
-func (r Brand) Filter(filter string) Brand {
+func (r Brand) Filter(filter interface{}) Brand {
 	r.Options.Filter = filter
 	return r
 }
@@ -251,7 +251,7 @@ func (r Brand_Restriction_Location_CustomerCountry) Mask(mask string) Brand_Rest
 	return r
 }
 
-func (r Brand_Restriction_Location_CustomerCountry) Filter(filter string) Brand_Restriction_Location_CustomerCountry {
+func (r Brand_Restriction_Location_CustomerCountry) Filter(filter interface{}) Brand_Restriction_Location_CustomerCountry {
 	r.Options.Filter = filter
 	return r
 }

--- a/services/catalyst.go
+++ b/services/catalyst.go
@@ -53,7 +53,7 @@ func (r Catalyst_Company_Type) Mask(mask string) Catalyst_Company_Type {
 	return r
 }
 
-func (r Catalyst_Company_Type) Filter(filter string) Catalyst_Company_Type {
+func (r Catalyst_Company_Type) Filter(filter interface{}) Catalyst_Company_Type {
 	r.Options.Filter = filter
 	return r
 }
@@ -104,7 +104,7 @@ func (r Catalyst_Enrollment) Mask(mask string) Catalyst_Enrollment {
 	return r
 }
 
-func (r Catalyst_Enrollment) Filter(filter string) Catalyst_Enrollment {
+func (r Catalyst_Enrollment) Filter(filter interface{}) Catalyst_Enrollment {
 	r.Options.Filter = filter
 	return r
 }

--- a/services/compliance.go
+++ b/services/compliance.go
@@ -53,7 +53,7 @@ func (r Compliance_Report_Type) Mask(mask string) Compliance_Report_Type {
 	return r
 }
 
-func (r Compliance_Report_Type) Filter(filter string) Compliance_Report_Type {
+func (r Compliance_Report_Type) Filter(filter interface{}) Compliance_Report_Type {
 	r.Options.Filter = filter
 	return r
 }

--- a/services/configuration.go
+++ b/services/configuration.go
@@ -53,7 +53,7 @@ func (r Configuration_Storage_Group_Array_Type) Mask(mask string) Configuration_
 	return r
 }
 
-func (r Configuration_Storage_Group_Array_Type) Filter(filter string) Configuration_Storage_Group_Array_Type {
+func (r Configuration_Storage_Group_Array_Type) Filter(filter interface{}) Configuration_Storage_Group_Array_Type {
 	r.Options.Filter = filter
 	return r
 }
@@ -110,7 +110,7 @@ func (r Configuration_Template) Mask(mask string) Configuration_Template {
 	return r
 }
 
-func (r Configuration_Template) Filter(filter string) Configuration_Template {
+func (r Configuration_Template) Filter(filter interface{}) Configuration_Template {
 	r.Options.Filter = filter
 	return r
 }
@@ -250,7 +250,7 @@ func (r Configuration_Template_Section) Mask(mask string) Configuration_Template
 	return r
 }
 
-func (r Configuration_Template_Section) Filter(filter string) Configuration_Template_Section {
+func (r Configuration_Template_Section) Filter(filter interface{}) Configuration_Template_Section {
 	r.Options.Filter = filter
 	return r
 }
@@ -359,7 +359,7 @@ func (r Configuration_Template_Section_Definition) Mask(mask string) Configurati
 	return r
 }
 
-func (r Configuration_Template_Section_Definition) Filter(filter string) Configuration_Template_Section_Definition {
+func (r Configuration_Template_Section_Definition) Filter(filter interface{}) Configuration_Template_Section_Definition {
 	r.Options.Filter = filter
 	return r
 }
@@ -442,7 +442,7 @@ func (r Configuration_Template_Section_Definition_Group) Mask(mask string) Confi
 	return r
 }
 
-func (r Configuration_Template_Section_Definition_Group) Filter(filter string) Configuration_Template_Section_Definition_Group {
+func (r Configuration_Template_Section_Definition_Group) Filter(filter interface{}) Configuration_Template_Section_Definition_Group {
 	r.Options.Filter = filter
 	return r
 }
@@ -501,7 +501,7 @@ func (r Configuration_Template_Section_Definition_Type) Mask(mask string) Config
 	return r
 }
 
-func (r Configuration_Template_Section_Definition_Type) Filter(filter string) Configuration_Template_Section_Definition_Type {
+func (r Configuration_Template_Section_Definition_Type) Filter(filter interface{}) Configuration_Template_Section_Definition_Type {
 	r.Options.Filter = filter
 	return r
 }
@@ -546,7 +546,7 @@ func (r Configuration_Template_Section_Definition_Value) Mask(mask string) Confi
 	return r
 }
 
-func (r Configuration_Template_Section_Definition_Value) Filter(filter string) Configuration_Template_Section_Definition_Value {
+func (r Configuration_Template_Section_Definition_Value) Filter(filter interface{}) Configuration_Template_Section_Definition_Value {
 	r.Options.Filter = filter
 	return r
 }
@@ -605,7 +605,7 @@ func (r Configuration_Template_Section_Profile) Mask(mask string) Configuration_
 	return r
 }
 
-func (r Configuration_Template_Section_Profile) Filter(filter string) Configuration_Template_Section_Profile {
+func (r Configuration_Template_Section_Profile) Filter(filter interface{}) Configuration_Template_Section_Profile {
 	r.Options.Filter = filter
 	return r
 }
@@ -662,7 +662,7 @@ func (r Configuration_Template_Section_Reference) Mask(mask string) Configuratio
 	return r
 }
 
-func (r Configuration_Template_Section_Reference) Filter(filter string) Configuration_Template_Section_Reference {
+func (r Configuration_Template_Section_Reference) Filter(filter interface{}) Configuration_Template_Section_Reference {
 	r.Options.Filter = filter
 	return r
 }
@@ -721,7 +721,7 @@ func (r Configuration_Template_Section_Type) Mask(mask string) Configuration_Tem
 	return r
 }
 
-func (r Configuration_Template_Section_Type) Filter(filter string) Configuration_Template_Section_Type {
+func (r Configuration_Template_Section_Type) Filter(filter interface{}) Configuration_Template_Section_Type {
 	r.Options.Filter = filter
 	return r
 }
@@ -766,7 +766,7 @@ func (r Configuration_Template_Type) Mask(mask string) Configuration_Template_Ty
 	return r
 }
 
-func (r Configuration_Template_Type) Filter(filter string) Configuration_Template_Type {
+func (r Configuration_Template_Type) Filter(filter interface{}) Configuration_Template_Type {
 	r.Options.Filter = filter
 	return r
 }

--- a/services/dns.go
+++ b/services/dns.go
@@ -53,7 +53,7 @@ func (r Dns_Domain) Mask(mask string) Dns_Domain {
 	return r
 }
 
-func (r Dns_Domain) Filter(filter string) Dns_Domain {
+func (r Dns_Domain) Filter(filter interface{}) Dns_Domain {
 	r.Options.Filter = filter
 	return r
 }
@@ -266,7 +266,7 @@ func (r Dns_Domain_Registration) Mask(mask string) Dns_Domain_Registration {
 	return r
 }
 
-func (r Dns_Domain_Registration) Filter(filter string) Dns_Domain_Registration {
+func (r Dns_Domain_Registration) Filter(filter interface{}) Dns_Domain_Registration {
 	r.Options.Filter = filter
 	return r
 }
@@ -500,7 +500,7 @@ func (r Dns_Domain_Registration_Registrant_Verification_Status) Mask(mask string
 	return r
 }
 
-func (r Dns_Domain_Registration_Registrant_Verification_Status) Filter(filter string) Dns_Domain_Registration_Registrant_Verification_Status {
+func (r Dns_Domain_Registration_Registrant_Verification_Status) Filter(filter interface{}) Dns_Domain_Registration_Registrant_Verification_Status {
 	r.Options.Filter = filter
 	return r
 }
@@ -560,7 +560,7 @@ func (r Dns_Domain_Registration_Status) Mask(mask string) Dns_Domain_Registratio
 	return r
 }
 
-func (r Dns_Domain_Registration_Status) Filter(filter string) Dns_Domain_Registration_Status {
+func (r Dns_Domain_Registration_Status) Filter(filter interface{}) Dns_Domain_Registration_Status {
 	r.Options.Filter = filter
 	return r
 }
@@ -624,7 +624,7 @@ func (r Dns_Domain_ResourceRecord) Mask(mask string) Dns_Domain_ResourceRecord {
 	return r
 }
 
-func (r Dns_Domain_ResourceRecord) Filter(filter string) Dns_Domain_ResourceRecord {
+func (r Dns_Domain_ResourceRecord) Filter(filter interface{}) Dns_Domain_ResourceRecord {
 	r.Options.Filter = filter
 	return r
 }
@@ -742,7 +742,7 @@ func (r Dns_Domain_ResourceRecord_MxType) Mask(mask string) Dns_Domain_ResourceR
 	return r
 }
 
-func (r Dns_Domain_ResourceRecord_MxType) Filter(filter string) Dns_Domain_ResourceRecord_MxType {
+func (r Dns_Domain_ResourceRecord_MxType) Filter(filter interface{}) Dns_Domain_ResourceRecord_MxType {
 	r.Options.Filter = filter
 	return r
 }
@@ -854,7 +854,7 @@ func (r Dns_Domain_ResourceRecord_SrvType) Mask(mask string) Dns_Domain_Resource
 	return r
 }
 
-func (r Dns_Domain_ResourceRecord_SrvType) Filter(filter string) Dns_Domain_ResourceRecord_SrvType {
+func (r Dns_Domain_ResourceRecord_SrvType) Filter(filter interface{}) Dns_Domain_ResourceRecord_SrvType {
 	r.Options.Filter = filter
 	return r
 }
@@ -966,7 +966,7 @@ func (r Dns_Secondary) Mask(mask string) Dns_Secondary {
 	return r
 }
 
-func (r Dns_Secondary) Filter(filter string) Dns_Secondary {
+func (r Dns_Secondary) Filter(filter interface{}) Dns_Secondary {
 	r.Options.Filter = filter
 	return r
 }

--- a/services/event.go
+++ b/services/event.go
@@ -53,7 +53,7 @@ func (r Event_Log) Mask(mask string) Event_Log {
 	return r
 }
 
-func (r Event_Log) Filter(filter string) Event_Log {
+func (r Event_Log) Filter(filter interface{}) Event_Log {
 	r.Options.Filter = filter
 	return r
 }

--- a/services/flexiblecredit.go
+++ b/services/flexiblecredit.go
@@ -53,7 +53,7 @@ func (r FlexibleCredit_Program) Mask(mask string) FlexibleCredit_Program {
 	return r
 }
 
-func (r FlexibleCredit_Program) Filter(filter string) FlexibleCredit_Program {
+func (r FlexibleCredit_Program) Filter(filter interface{}) FlexibleCredit_Program {
 	r.Options.Filter = filter
 	return r
 }

--- a/services/hardware.go
+++ b/services/hardware.go
@@ -53,7 +53,7 @@ func (r Hardware) Mask(mask string) Hardware {
 	return r
 }
 
-func (r Hardware) Filter(filter string) Hardware {
+func (r Hardware) Filter(filter interface{}) Hardware {
 	r.Options.Filter = filter
 	return r
 }
@@ -1527,7 +1527,7 @@ func (r Hardware_Benchmark_Certification) Mask(mask string) Hardware_Benchmark_C
 	return r
 }
 
-func (r Hardware_Benchmark_Certification) Filter(filter string) Hardware_Benchmark_Certification {
+func (r Hardware_Benchmark_Certification) Filter(filter interface{}) Hardware_Benchmark_Certification {
 	r.Options.Filter = filter
 	return r
 }
@@ -1590,7 +1590,7 @@ func (r Hardware_Component_Model) Mask(mask string) Hardware_Component_Model {
 	return r
 }
 
-func (r Hardware_Component_Model) Filter(filter string) Hardware_Component_Model {
+func (r Hardware_Component_Model) Filter(filter interface{}) Hardware_Component_Model {
 	r.Options.Filter = filter
 	return r
 }
@@ -1707,7 +1707,7 @@ func (r Hardware_Component_Partition_OperatingSystem) Mask(mask string) Hardware
 	return r
 }
 
-func (r Hardware_Component_Partition_OperatingSystem) Filter(filter string) Hardware_Component_Partition_OperatingSystem {
+func (r Hardware_Component_Partition_OperatingSystem) Filter(filter interface{}) Hardware_Component_Partition_OperatingSystem {
 	r.Options.Filter = filter
 	return r
 }
@@ -1773,7 +1773,7 @@ func (r Hardware_Component_Partition_Template) Mask(mask string) Hardware_Compon
 	return r
 }
 
-func (r Hardware_Component_Partition_Template) Filter(filter string) Hardware_Component_Partition_Template {
+func (r Hardware_Component_Partition_Template) Filter(filter interface{}) Hardware_Component_Partition_Template {
 	r.Options.Filter = filter
 	return r
 }
@@ -1848,7 +1848,7 @@ func (r Hardware_Router) Mask(mask string) Hardware_Router {
 	return r
 }
 
-func (r Hardware_Router) Filter(filter string) Hardware_Router {
+func (r Hardware_Router) Filter(filter interface{}) Hardware_Router {
 	r.Options.Filter = filter
 	return r
 }
@@ -3340,7 +3340,7 @@ func (r Hardware_SecurityModule) Mask(mask string) Hardware_SecurityModule {
 	return r
 }
 
-func (r Hardware_SecurityModule) Filter(filter string) Hardware_SecurityModule {
+func (r Hardware_SecurityModule) Filter(filter interface{}) Hardware_SecurityModule {
 	r.Options.Filter = filter
 	return r
 }
@@ -5444,7 +5444,7 @@ func (r Hardware_Server) Mask(mask string) Hardware_Server {
 	return r
 }
 
-func (r Hardware_Server) Filter(filter string) Hardware_Server {
+func (r Hardware_Server) Filter(filter interface{}) Hardware_Server {
 	r.Options.Filter = filter
 	return r
 }

--- a/services/layout.go
+++ b/services/layout.go
@@ -53,7 +53,7 @@ func (r Layout_Container) Mask(mask string) Layout_Container {
 	return r
 }
 
-func (r Layout_Container) Filter(filter string) Layout_Container {
+func (r Layout_Container) Filter(filter interface{}) Layout_Container {
 	r.Options.Filter = filter
 	return r
 }
@@ -116,7 +116,7 @@ func (r Layout_Item) Mask(mask string) Layout_Item {
 	return r
 }
 
-func (r Layout_Item) Filter(filter string) Layout_Item {
+func (r Layout_Item) Filter(filter interface{}) Layout_Item {
 	r.Options.Filter = filter
 	return r
 }
@@ -173,7 +173,7 @@ func (r Layout_Profile) Mask(mask string) Layout_Profile {
 	return r
 }
 
-func (r Layout_Profile) Filter(filter string) Layout_Profile {
+func (r Layout_Profile) Filter(filter interface{}) Layout_Profile {
 	r.Options.Filter = filter
 	return r
 }
@@ -276,7 +276,7 @@ func (r Layout_Profile_Containers) Mask(mask string) Layout_Profile_Containers {
 	return r
 }
 
-func (r Layout_Profile_Containers) Filter(filter string) Layout_Profile_Containers {
+func (r Layout_Profile_Containers) Filter(filter interface{}) Layout_Profile_Containers {
 	r.Options.Filter = filter
 	return r
 }
@@ -351,7 +351,7 @@ func (r Layout_Profile_Customer) Mask(mask string) Layout_Profile_Customer {
 	return r
 }
 
-func (r Layout_Profile_Customer) Filter(filter string) Layout_Profile_Customer {
+func (r Layout_Profile_Customer) Filter(filter interface{}) Layout_Profile_Customer {
 	r.Options.Filter = filter
 	return r
 }
@@ -460,7 +460,7 @@ func (r Layout_Profile_Preference) Mask(mask string) Layout_Profile_Preference {
 	return r
 }
 
-func (r Layout_Profile_Preference) Filter(filter string) Layout_Profile_Preference {
+func (r Layout_Profile_Preference) Filter(filter interface{}) Layout_Profile_Preference {
 	r.Options.Filter = filter
 	return r
 }

--- a/services/locale.go
+++ b/services/locale.go
@@ -53,7 +53,7 @@ func (r Locale) Mask(mask string) Locale {
 	return r
 }
 
-func (r Locale) Filter(filter string) Locale {
+func (r Locale) Filter(filter interface{}) Locale {
 	r.Options.Filter = filter
 	return r
 }
@@ -107,7 +107,7 @@ func (r Locale_Country) Mask(mask string) Locale_Country {
 	return r
 }
 
-func (r Locale_Country) Filter(filter string) Locale_Country {
+func (r Locale_Country) Filter(filter interface{}) Locale_Country {
 	r.Options.Filter = filter
 	return r
 }
@@ -170,7 +170,7 @@ func (r Locale_Timezone) Mask(mask string) Locale_Timezone {
 	return r
 }
 
-func (r Locale_Timezone) Filter(filter string) Locale_Timezone {
+func (r Locale_Timezone) Filter(filter interface{}) Locale_Timezone {
 	r.Options.Filter = filter
 	return r
 }

--- a/services/location.go
+++ b/services/location.go
@@ -53,7 +53,7 @@ func (r Location) Mask(mask string) Location {
 	return r
 }
 
-func (r Location) Filter(filter string) Location {
+func (r Location) Filter(filter interface{}) Location {
 	r.Options.Filter = filter
 	return r
 }
@@ -224,7 +224,7 @@ func (r Location_Datacenter) Mask(mask string) Location_Datacenter {
 	return r
 }
 
-func (r Location_Datacenter) Filter(filter string) Location_Datacenter {
+func (r Location_Datacenter) Filter(filter interface{}) Location_Datacenter {
 	r.Options.Filter = filter
 	return r
 }
@@ -467,7 +467,7 @@ func (r Location_Group) Mask(mask string) Location_Group {
 	return r
 }
 
-func (r Location_Group) Filter(filter string) Location_Group {
+func (r Location_Group) Filter(filter interface{}) Location_Group {
 	r.Options.Filter = filter
 	return r
 }
@@ -530,7 +530,7 @@ func (r Location_Group_Pricing) Mask(mask string) Location_Group_Pricing {
 	return r
 }
 
-func (r Location_Group_Pricing) Filter(filter string) Location_Group_Pricing {
+func (r Location_Group_Pricing) Filter(filter interface{}) Location_Group_Pricing {
 	r.Options.Filter = filter
 	return r
 }
@@ -599,7 +599,7 @@ func (r Location_Group_Regional) Mask(mask string) Location_Group_Regional {
 	return r
 }
 
-func (r Location_Group_Regional) Filter(filter string) Location_Group_Regional {
+func (r Location_Group_Regional) Filter(filter interface{}) Location_Group_Regional {
 	r.Options.Filter = filter
 	return r
 }
@@ -674,7 +674,7 @@ func (r Location_Reservation) Mask(mask string) Location_Reservation {
 	return r
 }
 
-func (r Location_Reservation) Filter(filter string) Location_Reservation {
+func (r Location_Reservation) Filter(filter interface{}) Location_Reservation {
 	r.Options.Filter = filter
 	return r
 }
@@ -755,7 +755,7 @@ func (r Location_Reservation_Rack) Mask(mask string) Location_Reservation_Rack {
 	return r
 }
 
-func (r Location_Reservation_Rack) Filter(filter string) Location_Reservation_Rack {
+func (r Location_Reservation_Rack) Filter(filter interface{}) Location_Reservation_Rack {
 	r.Options.Filter = filter
 	return r
 }
@@ -824,7 +824,7 @@ func (r Location_Reservation_Rack_Member) Mask(mask string) Location_Reservation
 	return r
 }
 
-func (r Location_Reservation_Rack_Member) Filter(filter string) Location_Reservation_Rack_Member {
+func (r Location_Reservation_Rack_Member) Filter(filter interface{}) Location_Reservation_Rack_Member {
 	r.Options.Filter = filter
 	return r
 }

--- a/services/marketplace.go
+++ b/services/marketplace.go
@@ -53,7 +53,7 @@ func (r Marketplace_Partner) Mask(mask string) Marketplace_Partner {
 	return r
 }
 
-func (r Marketplace_Partner) Filter(filter string) Marketplace_Partner {
+func (r Marketplace_Partner) Filter(filter interface{}) Marketplace_Partner {
 	r.Options.Filter = filter
 	return r
 }

--- a/services/metric.go
+++ b/services/metric.go
@@ -53,7 +53,7 @@ func (r Metric_Tracking_Object) Mask(mask string) Metric_Tracking_Object {
 	return r
 }
 
-func (r Metric_Tracking_Object) Filter(filter string) Metric_Tracking_Object {
+func (r Metric_Tracking_Object) Filter(filter interface{}) Metric_Tracking_Object {
 	r.Options.Filter = filter
 	return r
 }
@@ -210,7 +210,7 @@ func (r Metric_Tracking_Object_Bandwidth_Summary) Mask(mask string) Metric_Track
 	return r
 }
 
-func (r Metric_Tracking_Object_Bandwidth_Summary) Filter(filter string) Metric_Tracking_Object_Bandwidth_Summary {
+func (r Metric_Tracking_Object_Bandwidth_Summary) Filter(filter interface{}) Metric_Tracking_Object_Bandwidth_Summary {
 	r.Options.Filter = filter
 	return r
 }

--- a/services/monitoring.go
+++ b/services/monitoring.go
@@ -53,7 +53,7 @@ func (r Monitoring_Agent) Mask(mask string) Monitoring_Agent {
 	return r
 }
 
-func (r Monitoring_Agent) Filter(filter string) Monitoring_Agent {
+func (r Monitoring_Agent) Filter(filter interface{}) Monitoring_Agent {
 	r.Options.Filter = filter
 	return r
 }
@@ -281,7 +281,7 @@ func (r Monitoring_Agent_Configuration_Template_Group) Mask(mask string) Monitor
 	return r
 }
 
-func (r Monitoring_Agent_Configuration_Template_Group) Filter(filter string) Monitoring_Agent_Configuration_Template_Group {
+func (r Monitoring_Agent_Configuration_Template_Group) Filter(filter interface{}) Monitoring_Agent_Configuration_Template_Group {
 	r.Options.Filter = filter
 	return r
 }
@@ -389,7 +389,7 @@ func (r Monitoring_Agent_Configuration_Template_Group_Reference) Mask(mask strin
 	return r
 }
 
-func (r Monitoring_Agent_Configuration_Template_Group_Reference) Filter(filter string) Monitoring_Agent_Configuration_Template_Group_Reference {
+func (r Monitoring_Agent_Configuration_Template_Group_Reference) Filter(filter interface{}) Monitoring_Agent_Configuration_Template_Group_Reference {
 	r.Options.Filter = filter
 	return r
 }
@@ -488,7 +488,7 @@ func (r Monitoring_Agent_Configuration_Value) Mask(mask string) Monitoring_Agent
 	return r
 }
 
-func (r Monitoring_Agent_Configuration_Value) Filter(filter string) Monitoring_Agent_Configuration_Value {
+func (r Monitoring_Agent_Configuration_Value) Filter(filter interface{}) Monitoring_Agent_Configuration_Value {
 	r.Options.Filter = filter
 	return r
 }
@@ -557,7 +557,7 @@ func (r Monitoring_Agent_Status) Mask(mask string) Monitoring_Agent_Status {
 	return r
 }
 
-func (r Monitoring_Agent_Status) Filter(filter string) Monitoring_Agent_Status {
+func (r Monitoring_Agent_Status) Filter(filter interface{}) Monitoring_Agent_Status {
 	r.Options.Filter = filter
 	return r
 }
@@ -602,7 +602,7 @@ func (r Monitoring_Robot) Mask(mask string) Monitoring_Robot {
 	return r
 }
 
-func (r Monitoring_Robot) Filter(filter string) Monitoring_Robot {
+func (r Monitoring_Robot) Filter(filter interface{}) Monitoring_Robot {
 	r.Options.Filter = filter
 	return r
 }

--- a/services/network.go
+++ b/services/network.go
@@ -53,7 +53,7 @@ func (r Network) Mask(mask string) Network {
 	return r
 }
 
-func (r Network) Filter(filter string) Network {
+func (r Network) Filter(filter interface{}) Network {
 	r.Options.Filter = filter
 	return r
 }
@@ -218,7 +218,7 @@ func (r Network_Application_Delivery_Controller) Mask(mask string) Network_Appli
 	return r
 }
 
-func (r Network_Application_Delivery_Controller) Filter(filter string) Network_Application_Delivery_Controller {
+func (r Network_Application_Delivery_Controller) Filter(filter interface{}) Network_Application_Delivery_Controller {
 	r.Options.Filter = filter
 	return r
 }
@@ -507,7 +507,7 @@ func (r Network_Application_Delivery_Controller_Configuration_History) Mask(mask
 	return r
 }
 
-func (r Network_Application_Delivery_Controller_Configuration_History) Filter(filter string) Network_Application_Delivery_Controller_Configuration_History {
+func (r Network_Application_Delivery_Controller_Configuration_History) Filter(filter interface{}) Network_Application_Delivery_Controller_Configuration_History {
 	r.Options.Filter = filter
 	return r
 }
@@ -564,7 +564,7 @@ func (r Network_Application_Delivery_Controller_LoadBalancer_Health_Attribute) M
 	return r
 }
 
-func (r Network_Application_Delivery_Controller_LoadBalancer_Health_Attribute) Filter(filter string) Network_Application_Delivery_Controller_LoadBalancer_Health_Attribute {
+func (r Network_Application_Delivery_Controller_LoadBalancer_Health_Attribute) Filter(filter interface{}) Network_Application_Delivery_Controller_LoadBalancer_Health_Attribute {
 	r.Options.Filter = filter
 	return r
 }
@@ -621,7 +621,7 @@ func (r Network_Application_Delivery_Controller_LoadBalancer_Health_Attribute_Ty
 	return r
 }
 
-func (r Network_Application_Delivery_Controller_LoadBalancer_Health_Attribute_Type) Filter(filter string) Network_Application_Delivery_Controller_LoadBalancer_Health_Attribute_Type {
+func (r Network_Application_Delivery_Controller_LoadBalancer_Health_Attribute_Type) Filter(filter interface{}) Network_Application_Delivery_Controller_LoadBalancer_Health_Attribute_Type {
 	r.Options.Filter = filter
 	return r
 }
@@ -672,7 +672,7 @@ func (r Network_Application_Delivery_Controller_LoadBalancer_Health_Check) Mask(
 	return r
 }
 
-func (r Network_Application_Delivery_Controller_LoadBalancer_Health_Check) Filter(filter string) Network_Application_Delivery_Controller_LoadBalancer_Health_Check {
+func (r Network_Application_Delivery_Controller_LoadBalancer_Health_Check) Filter(filter interface{}) Network_Application_Delivery_Controller_LoadBalancer_Health_Check {
 	r.Options.Filter = filter
 	return r
 }
@@ -741,7 +741,7 @@ func (r Network_Application_Delivery_Controller_LoadBalancer_Health_Check_Type) 
 	return r
 }
 
-func (r Network_Application_Delivery_Controller_LoadBalancer_Health_Check_Type) Filter(filter string) Network_Application_Delivery_Controller_LoadBalancer_Health_Check_Type {
+func (r Network_Application_Delivery_Controller_LoadBalancer_Health_Check_Type) Filter(filter interface{}) Network_Application_Delivery_Controller_LoadBalancer_Health_Check_Type {
 	r.Options.Filter = filter
 	return r
 }
@@ -792,7 +792,7 @@ func (r Network_Application_Delivery_Controller_LoadBalancer_Routing_Method) Mas
 	return r
 }
 
-func (r Network_Application_Delivery_Controller_LoadBalancer_Routing_Method) Filter(filter string) Network_Application_Delivery_Controller_LoadBalancer_Routing_Method {
+func (r Network_Application_Delivery_Controller_LoadBalancer_Routing_Method) Filter(filter interface{}) Network_Application_Delivery_Controller_LoadBalancer_Routing_Method {
 	r.Options.Filter = filter
 	return r
 }
@@ -843,7 +843,7 @@ func (r Network_Application_Delivery_Controller_LoadBalancer_Routing_Type) Mask(
 	return r
 }
 
-func (r Network_Application_Delivery_Controller_LoadBalancer_Routing_Type) Filter(filter string) Network_Application_Delivery_Controller_LoadBalancer_Routing_Type {
+func (r Network_Application_Delivery_Controller_LoadBalancer_Routing_Type) Filter(filter interface{}) Network_Application_Delivery_Controller_LoadBalancer_Routing_Type {
 	r.Options.Filter = filter
 	return r
 }
@@ -894,7 +894,7 @@ func (r Network_Application_Delivery_Controller_LoadBalancer_Service) Mask(mask 
 	return r
 }
 
-func (r Network_Application_Delivery_Controller_LoadBalancer_Service) Filter(filter string) Network_Application_Delivery_Controller_LoadBalancer_Service {
+func (r Network_Application_Delivery_Controller_LoadBalancer_Service) Filter(filter interface{}) Network_Application_Delivery_Controller_LoadBalancer_Service {
 	r.Options.Filter = filter
 	return r
 }
@@ -1000,7 +1000,7 @@ func (r Network_Application_Delivery_Controller_LoadBalancer_Service_Group) Mask
 	return r
 }
 
-func (r Network_Application_Delivery_Controller_LoadBalancer_Service_Group) Filter(filter string) Network_Application_Delivery_Controller_LoadBalancer_Service_Group {
+func (r Network_Application_Delivery_Controller_LoadBalancer_Service_Group) Filter(filter interface{}) Network_Application_Delivery_Controller_LoadBalancer_Service_Group {
 	r.Options.Filter = filter
 	return r
 }
@@ -1099,7 +1099,7 @@ func (r Network_Application_Delivery_Controller_LoadBalancer_VirtualIpAddress) M
 	return r
 }
 
-func (r Network_Application_Delivery_Controller_LoadBalancer_VirtualIpAddress) Filter(filter string) Network_Application_Delivery_Controller_LoadBalancer_VirtualIpAddress {
+func (r Network_Application_Delivery_Controller_LoadBalancer_VirtualIpAddress) Filter(filter interface{}) Network_Application_Delivery_Controller_LoadBalancer_VirtualIpAddress {
 	r.Options.Filter = filter
 	return r
 }
@@ -1267,7 +1267,7 @@ func (r Network_Application_Delivery_Controller_LoadBalancer_VirtualServer) Mask
 	return r
 }
 
-func (r Network_Application_Delivery_Controller_LoadBalancer_VirtualServer) Filter(filter string) Network_Application_Delivery_Controller_LoadBalancer_VirtualServer {
+func (r Network_Application_Delivery_Controller_LoadBalancer_VirtualServer) Filter(filter interface{}) Network_Application_Delivery_Controller_LoadBalancer_VirtualServer {
 	r.Options.Filter = filter
 	return r
 }
@@ -1355,7 +1355,7 @@ func (r Network_Backbone) Mask(mask string) Network_Backbone {
 	return r
 }
 
-func (r Network_Backbone) Filter(filter string) Network_Backbone {
+func (r Network_Backbone) Filter(filter interface{}) Network_Backbone {
 	r.Options.Filter = filter
 	return r
 }
@@ -1439,7 +1439,7 @@ func (r Network_Backbone_Location_Dependent) Mask(mask string) Network_Backbone_
 	return r
 }
 
-func (r Network_Backbone_Location_Dependent) Filter(filter string) Network_Backbone_Location_Dependent {
+func (r Network_Backbone_Location_Dependent) Filter(filter interface{}) Network_Backbone_Location_Dependent {
 	r.Options.Filter = filter
 	return r
 }
@@ -1511,7 +1511,7 @@ func (r Network_Bandwidth_Version1_Allotment) Mask(mask string) Network_Bandwidt
 	return r
 }
 
-func (r Network_Bandwidth_Version1_Allotment) Filter(filter string) Network_Bandwidth_Version1_Allotment {
+func (r Network_Bandwidth_Version1_Allotment) Filter(filter interface{}) Network_Bandwidth_Version1_Allotment {
 	r.Options.Filter = filter
 	return r
 }
@@ -1881,7 +1881,7 @@ func (r Network_Component) Mask(mask string) Network_Component {
 	return r
 }
 
-func (r Network_Component) Filter(filter string) Network_Component {
+func (r Network_Component) Filter(filter interface{}) Network_Component {
 	r.Options.Filter = filter
 	return r
 }
@@ -2146,7 +2146,7 @@ func (r Network_Component_Firewall) Mask(mask string) Network_Component_Firewall
 	return r
 }
 
-func (r Network_Component_Firewall) Filter(filter string) Network_Component_Firewall {
+func (r Network_Component_Firewall) Filter(filter interface{}) Network_Component_Firewall {
 	r.Options.Filter = filter
 	return r
 }
@@ -2233,7 +2233,7 @@ func (r Network_ContentDelivery_Account) Mask(mask string) Network_ContentDelive
 	return r
 }
 
-func (r Network_ContentDelivery_Account) Filter(filter string) Network_ContentDelivery_Account {
+func (r Network_ContentDelivery_Account) Filter(filter interface{}) Network_ContentDelivery_Account {
 	r.Options.Filter = filter
 	return r
 }
@@ -2736,7 +2736,7 @@ func (r Network_ContentDelivery_Authentication_Address) Mask(mask string) Networ
 	return r
 }
 
-func (r Network_ContentDelivery_Authentication_Address) Filter(filter string) Network_ContentDelivery_Authentication_Address {
+func (r Network_ContentDelivery_Authentication_Address) Filter(filter interface{}) Network_ContentDelivery_Authentication_Address {
 	r.Options.Filter = filter
 	return r
 }
@@ -2822,7 +2822,7 @@ func (r Network_ContentDelivery_Authentication_Token) Mask(mask string) Network_
 	return r
 }
 
-func (r Network_ContentDelivery_Authentication_Token) Filter(filter string) Network_ContentDelivery_Authentication_Token {
+func (r Network_ContentDelivery_Authentication_Token) Filter(filter interface{}) Network_ContentDelivery_Authentication_Token {
 	r.Options.Filter = filter
 	return r
 }
@@ -2959,7 +2959,7 @@ func (r Network_Customer_Subnet) Mask(mask string) Network_Customer_Subnet {
 	return r
 }
 
-func (r Network_Customer_Subnet) Filter(filter string) Network_Customer_Subnet {
+func (r Network_Customer_Subnet) Filter(filter interface{}) Network_Customer_Subnet {
 	r.Options.Filter = filter
 	return r
 }
@@ -3019,7 +3019,7 @@ func (r Network_Firewall_AccessControlList) Mask(mask string) Network_Firewall_A
 	return r
 }
 
-func (r Network_Firewall_AccessControlList) Filter(filter string) Network_Firewall_AccessControlList {
+func (r Network_Firewall_AccessControlList) Filter(filter interface{}) Network_Firewall_AccessControlList {
 	r.Options.Filter = filter
 	return r
 }
@@ -3082,7 +3082,7 @@ func (r Network_Firewall_Interface) Mask(mask string) Network_Firewall_Interface
 	return r
 }
 
-func (r Network_Firewall_Interface) Filter(filter string) Network_Firewall_Interface {
+func (r Network_Firewall_Interface) Filter(filter interface{}) Network_Firewall_Interface {
 	r.Options.Filter = filter
 	return r
 }
@@ -3139,7 +3139,7 @@ func (r Network_Firewall_Module_Context_Interface) Mask(mask string) Network_Fir
 	return r
 }
 
-func (r Network_Firewall_Module_Context_Interface) Filter(filter string) Network_Firewall_Module_Context_Interface {
+func (r Network_Firewall_Module_Context_Interface) Filter(filter interface{}) Network_Firewall_Module_Context_Interface {
 	r.Options.Filter = filter
 	return r
 }
@@ -3198,7 +3198,7 @@ func (r Network_Firewall_Template) Mask(mask string) Network_Firewall_Template {
 	return r
 }
 
-func (r Network_Firewall_Template) Filter(filter string) Network_Firewall_Template {
+func (r Network_Firewall_Template) Filter(filter interface{}) Network_Firewall_Template {
 	r.Options.Filter = filter
 	return r
 }
@@ -3259,7 +3259,7 @@ func (r Network_Firewall_Update_Request) Mask(mask string) Network_Firewall_Upda
 	return r
 }
 
-func (r Network_Firewall_Update_Request) Filter(filter string) Network_Firewall_Update_Request {
+func (r Network_Firewall_Update_Request) Filter(filter interface{}) Network_Firewall_Update_Request {
 	r.Options.Filter = filter
 	return r
 }
@@ -3363,7 +3363,7 @@ func (r Network_Firewall_Update_Request_Rule) Mask(mask string) Network_Firewall
 	return r
 }
 
-func (r Network_Firewall_Update_Request_Rule) Filter(filter string) Network_Firewall_Update_Request_Rule {
+func (r Network_Firewall_Update_Request_Rule) Filter(filter interface{}) Network_Firewall_Update_Request_Rule {
 	r.Options.Filter = filter
 	return r
 }
@@ -3439,7 +3439,7 @@ func (r Network_Gateway) Mask(mask string) Network_Gateway {
 	return r
 }
 
-func (r Network_Gateway) Filter(filter string) Network_Gateway {
+func (r Network_Gateway) Filter(filter interface{}) Network_Gateway {
 	r.Options.Filter = filter
 	return r
 }
@@ -3596,7 +3596,7 @@ func (r Network_Gateway_Member) Mask(mask string) Network_Gateway_Member {
 	return r
 }
 
-func (r Network_Gateway_Member) Filter(filter string) Network_Gateway_Member {
+func (r Network_Gateway_Member) Filter(filter interface{}) Network_Gateway_Member {
 	r.Options.Filter = filter
 	return r
 }
@@ -3671,7 +3671,7 @@ func (r Network_Gateway_Status) Mask(mask string) Network_Gateway_Status {
 	return r
 }
 
-func (r Network_Gateway_Status) Filter(filter string) Network_Gateway_Status {
+func (r Network_Gateway_Status) Filter(filter interface{}) Network_Gateway_Status {
 	r.Options.Filter = filter
 	return r
 }
@@ -3716,7 +3716,7 @@ func (r Network_Gateway_Vlan) Mask(mask string) Network_Gateway_Vlan {
 	return r
 }
 
-func (r Network_Gateway_Vlan) Filter(filter string) Network_Gateway_Vlan {
+func (r Network_Gateway_Vlan) Filter(filter interface{}) Network_Gateway_Vlan {
 	r.Options.Filter = filter
 	return r
 }
@@ -3821,7 +3821,7 @@ func (r Network_LoadBalancer_Global_Account) Mask(mask string) Network_LoadBalan
 	return r
 }
 
-func (r Network_LoadBalancer_Global_Account) Filter(filter string) Network_LoadBalancer_Global_Account {
+func (r Network_LoadBalancer_Global_Account) Filter(filter interface{}) Network_LoadBalancer_Global_Account {
 	r.Options.Filter = filter
 	return r
 }
@@ -3946,7 +3946,7 @@ func (r Network_LoadBalancer_Global_Host) Mask(mask string) Network_LoadBalancer
 	return r
 }
 
-func (r Network_LoadBalancer_Global_Host) Filter(filter string) Network_LoadBalancer_Global_Host {
+func (r Network_LoadBalancer_Global_Host) Filter(filter interface{}) Network_LoadBalancer_Global_Host {
 	r.Options.Filter = filter
 	return r
 }
@@ -4005,7 +4005,7 @@ func (r Network_LoadBalancer_Service) Mask(mask string) Network_LoadBalancer_Ser
 	return r
 }
 
-func (r Network_LoadBalancer_Service) Filter(filter string) Network_LoadBalancer_Service {
+func (r Network_LoadBalancer_Service) Filter(filter interface{}) Network_LoadBalancer_Service {
 	r.Options.Filter = filter
 	return r
 }
@@ -4103,7 +4103,7 @@ func (r Network_LoadBalancer_VirtualIpAddress) Mask(mask string) Network_LoadBal
 	return r
 }
 
-func (r Network_LoadBalancer_VirtualIpAddress) Filter(filter string) Network_LoadBalancer_VirtualIpAddress {
+func (r Network_LoadBalancer_VirtualIpAddress) Filter(filter interface{}) Network_LoadBalancer_VirtualIpAddress {
 	r.Options.Filter = filter
 	return r
 }
@@ -4211,7 +4211,7 @@ func (r Network_Media_Transcode_Account) Mask(mask string) Network_Media_Transco
 	return r
 }
 
-func (r Network_Media_Transcode_Account) Filter(filter string) Network_Media_Transcode_Account {
+func (r Network_Media_Transcode_Account) Filter(filter interface{}) Network_Media_Transcode_Account {
 	r.Options.Filter = filter
 	return r
 }
@@ -4351,7 +4351,7 @@ func (r Network_Media_Transcode_Job) Mask(mask string) Network_Media_Transcode_J
 	return r
 }
 
-func (r Network_Media_Transcode_Job) Filter(filter string) Network_Media_Transcode_Job {
+func (r Network_Media_Transcode_Job) Filter(filter interface{}) Network_Media_Transcode_Job {
 	r.Options.Filter = filter
 	return r
 }
@@ -4459,7 +4459,7 @@ func (r Network_Media_Transcode_Job_Status) Mask(mask string) Network_Media_Tran
 	return r
 }
 
-func (r Network_Media_Transcode_Job_Status) Filter(filter string) Network_Media_Transcode_Job_Status {
+func (r Network_Media_Transcode_Job_Status) Filter(filter interface{}) Network_Media_Transcode_Job_Status {
 	r.Options.Filter = filter
 	return r
 }
@@ -4510,7 +4510,7 @@ func (r Network_Message_Delivery) Mask(mask string) Network_Message_Delivery {
 	return r
 }
 
-func (r Network_Message_Delivery) Filter(filter string) Network_Message_Delivery {
+func (r Network_Message_Delivery) Filter(filter interface{}) Network_Message_Delivery {
 	r.Options.Filter = filter
 	return r
 }
@@ -4588,7 +4588,7 @@ func (r Network_Message_Delivery_Email_Sendgrid) Mask(mask string) Network_Messa
 	return r
 }
 
-func (r Network_Message_Delivery_Email_Sendgrid) Filter(filter string) Network_Message_Delivery_Email_Sendgrid {
+func (r Network_Message_Delivery_Email_Sendgrid) Filter(filter interface{}) Network_Message_Delivery_Email_Sendgrid {
 	r.Options.Filter = filter
 	return r
 }
@@ -4772,7 +4772,7 @@ func (r Network_Message_Queue) Mask(mask string) Network_Message_Queue {
 	return r
 }
 
-func (r Network_Message_Queue) Filter(filter string) Network_Message_Queue {
+func (r Network_Message_Queue) Filter(filter interface{}) Network_Message_Queue {
 	r.Options.Filter = filter
 	return r
 }
@@ -4841,7 +4841,7 @@ func (r Network_Message_Queue_Node) Mask(mask string) Network_Message_Queue_Node
 	return r
 }
 
-func (r Network_Message_Queue_Node) Filter(filter string) Network_Message_Queue_Node {
+func (r Network_Message_Queue_Node) Filter(filter interface{}) Network_Message_Queue_Node {
 	r.Options.Filter = filter
 	return r
 }
@@ -4947,7 +4947,7 @@ func (r Network_Message_Queue_Status) Mask(mask string) Network_Message_Queue_St
 	return r
 }
 
-func (r Network_Message_Queue_Status) Filter(filter string) Network_Message_Queue_Status {
+func (r Network_Message_Queue_Status) Filter(filter interface{}) Network_Message_Queue_Status {
 	r.Options.Filter = filter
 	return r
 }
@@ -4992,7 +4992,7 @@ func (r Network_Monitor) Mask(mask string) Network_Monitor {
 	return r
 }
 
-func (r Network_Monitor) Filter(filter string) Network_Monitor {
+func (r Network_Monitor) Filter(filter interface{}) Network_Monitor {
 	r.Options.Filter = filter
 	return r
 }
@@ -5051,7 +5051,7 @@ func (r Network_Monitor_Version1_Query_Host) Mask(mask string) Network_Monitor_V
 	return r
 }
 
-func (r Network_Monitor_Version1_Query_Host) Filter(filter string) Network_Monitor_Version1_Query_Host {
+func (r Network_Monitor_Version1_Query_Host) Filter(filter interface{}) Network_Monitor_Version1_Query_Host {
 	r.Options.Filter = filter
 	return r
 }
@@ -5189,7 +5189,7 @@ func (r Network_Monitor_Version1_Query_Host_Stratum) Mask(mask string) Network_M
 	return r
 }
 
-func (r Network_Monitor_Version1_Query_Host_Stratum) Filter(filter string) Network_Monitor_Version1_Query_Host_Stratum {
+func (r Network_Monitor_Version1_Query_Host_Stratum) Filter(filter interface{}) Network_Monitor_Version1_Query_Host_Stratum {
 	r.Options.Filter = filter
 	return r
 }
@@ -5257,7 +5257,7 @@ func (r Network_Pod) Mask(mask string) Network_Pod {
 	return r
 }
 
-func (r Network_Pod) Filter(filter string) Network_Pod {
+func (r Network_Pod) Filter(filter interface{}) Network_Pod {
 	r.Options.Filter = filter
 	return r
 }
@@ -5325,7 +5325,7 @@ func (r Network_Security_Scanner_Request) Mask(mask string) Network_Security_Sca
 	return r
 }
 
-func (r Network_Security_Scanner_Request) Filter(filter string) Network_Security_Scanner_Request {
+func (r Network_Security_Scanner_Request) Filter(filter interface{}) Network_Security_Scanner_Request {
 	r.Options.Filter = filter
 	return r
 }
@@ -5415,7 +5415,7 @@ func (r Network_Service_Vpn_Overrides) Mask(mask string) Network_Service_Vpn_Ove
 	return r
 }
 
-func (r Network_Service_Vpn_Overrides) Filter(filter string) Network_Service_Vpn_Overrides {
+func (r Network_Service_Vpn_Overrides) Filter(filter interface{}) Network_Service_Vpn_Overrides {
 	r.Options.Filter = filter
 	return r
 }
@@ -5496,7 +5496,7 @@ func (r Network_Storage) Mask(mask string) Network_Storage {
 	return r
 }
 
-func (r Network_Storage) Filter(filter string) Network_Storage {
+func (r Network_Storage) Filter(filter interface{}) Network_Storage {
 	r.Options.Filter = filter
 	return r
 }
@@ -6708,7 +6708,7 @@ func (r Network_Storage_Allowed_Host) Mask(mask string) Network_Storage_Allowed_
 	return r
 }
 
-func (r Network_Storage_Allowed_Host) Filter(filter string) Network_Storage_Allowed_Host {
+func (r Network_Storage_Allowed_Host) Filter(filter interface{}) Network_Storage_Allowed_Host {
 	r.Options.Filter = filter
 	return r
 }
@@ -6810,7 +6810,7 @@ func (r Network_Storage_Allowed_Host_Hardware) Mask(mask string) Network_Storage
 	return r
 }
 
-func (r Network_Storage_Allowed_Host_Hardware) Filter(filter string) Network_Storage_Allowed_Host_Hardware {
+func (r Network_Storage_Allowed_Host_Hardware) Filter(filter interface{}) Network_Storage_Allowed_Host_Hardware {
 	r.Options.Filter = filter
 	return r
 }
@@ -6918,7 +6918,7 @@ func (r Network_Storage_Allowed_Host_IpAddress) Mask(mask string) Network_Storag
 	return r
 }
 
-func (r Network_Storage_Allowed_Host_IpAddress) Filter(filter string) Network_Storage_Allowed_Host_IpAddress {
+func (r Network_Storage_Allowed_Host_IpAddress) Filter(filter interface{}) Network_Storage_Allowed_Host_IpAddress {
 	r.Options.Filter = filter
 	return r
 }
@@ -7026,7 +7026,7 @@ func (r Network_Storage_Allowed_Host_Subnet) Mask(mask string) Network_Storage_A
 	return r
 }
 
-func (r Network_Storage_Allowed_Host_Subnet) Filter(filter string) Network_Storage_Allowed_Host_Subnet {
+func (r Network_Storage_Allowed_Host_Subnet) Filter(filter interface{}) Network_Storage_Allowed_Host_Subnet {
 	r.Options.Filter = filter
 	return r
 }
@@ -7134,7 +7134,7 @@ func (r Network_Storage_Allowed_Host_VirtualGuest) Mask(mask string) Network_Sto
 	return r
 }
 
-func (r Network_Storage_Allowed_Host_VirtualGuest) Filter(filter string) Network_Storage_Allowed_Host_VirtualGuest {
+func (r Network_Storage_Allowed_Host_VirtualGuest) Filter(filter interface{}) Network_Storage_Allowed_Host_VirtualGuest {
 	r.Options.Filter = filter
 	return r
 }
@@ -7242,7 +7242,7 @@ func (r Network_Storage_Backup_Evault) Mask(mask string) Network_Storage_Backup_
 	return r
 }
 
-func (r Network_Storage_Backup_Evault) Filter(filter string) Network_Storage_Backup_Evault {
+func (r Network_Storage_Backup_Evault) Filter(filter interface{}) Network_Storage_Backup_Evault {
 	r.Options.Filter = filter
 	return r
 }
@@ -8506,7 +8506,7 @@ func (r Network_Storage_Group) Mask(mask string) Network_Storage_Group {
 	return r
 }
 
-func (r Network_Storage_Group) Filter(filter string) Network_Storage_Group {
+func (r Network_Storage_Group) Filter(filter interface{}) Network_Storage_Group {
 	r.Options.Filter = filter
 	return r
 }
@@ -8659,7 +8659,7 @@ func (r Network_Storage_Group_Iscsi) Mask(mask string) Network_Storage_Group_Isc
 	return r
 }
 
-func (r Network_Storage_Group_Iscsi) Filter(filter string) Network_Storage_Group_Iscsi {
+func (r Network_Storage_Group_Iscsi) Filter(filter interface{}) Network_Storage_Group_Iscsi {
 	r.Options.Filter = filter
 	return r
 }
@@ -8812,7 +8812,7 @@ func (r Network_Storage_Group_Nfs) Mask(mask string) Network_Storage_Group_Nfs {
 	return r
 }
 
-func (r Network_Storage_Group_Nfs) Filter(filter string) Network_Storage_Group_Nfs {
+func (r Network_Storage_Group_Nfs) Filter(filter interface{}) Network_Storage_Group_Nfs {
 	r.Options.Filter = filter
 	return r
 }
@@ -8965,7 +8965,7 @@ func (r Network_Storage_Group_Type) Mask(mask string) Network_Storage_Group_Type
 	return r
 }
 
-func (r Network_Storage_Group_Type) Filter(filter string) Network_Storage_Group_Type {
+func (r Network_Storage_Group_Type) Filter(filter interface{}) Network_Storage_Group_Type {
 	r.Options.Filter = filter
 	return r
 }
@@ -9016,7 +9016,7 @@ func (r Network_Storage_Hub_Cleversafe_Account) Mask(mask string) Network_Storag
 	return r
 }
 
-func (r Network_Storage_Hub_Cleversafe_Account) Filter(filter string) Network_Storage_Hub_Cleversafe_Account {
+func (r Network_Storage_Hub_Cleversafe_Account) Filter(filter interface{}) Network_Storage_Hub_Cleversafe_Account {
 	r.Options.Filter = filter
 	return r
 }
@@ -9136,7 +9136,7 @@ func (r Network_Storage_Hub_Swift_Share) Mask(mask string) Network_Storage_Hub_S
 	return r
 }
 
-func (r Network_Storage_Hub_Swift_Share) Filter(filter string) Network_Storage_Hub_Swift_Share {
+func (r Network_Storage_Hub_Swift_Share) Filter(filter interface{}) Network_Storage_Hub_Swift_Share {
 	r.Options.Filter = filter
 	return r
 }
@@ -9201,7 +9201,7 @@ func (r Network_Storage_Iscsi) Mask(mask string) Network_Storage_Iscsi {
 	return r
 }
 
-func (r Network_Storage_Iscsi) Filter(filter string) Network_Storage_Iscsi {
+func (r Network_Storage_Iscsi) Filter(filter interface{}) Network_Storage_Iscsi {
 	r.Options.Filter = filter
 	return r
 }
@@ -10411,7 +10411,7 @@ func (r Network_Storage_Iscsi_OS_Type) Mask(mask string) Network_Storage_Iscsi_O
 	return r
 }
 
-func (r Network_Storage_Iscsi_OS_Type) Filter(filter string) Network_Storage_Iscsi_OS_Type {
+func (r Network_Storage_Iscsi_OS_Type) Filter(filter interface{}) Network_Storage_Iscsi_OS_Type {
 	r.Options.Filter = filter
 	return r
 }
@@ -10462,7 +10462,7 @@ func (r Network_Storage_Schedule) Mask(mask string) Network_Storage_Schedule {
 	return r
 }
 
-func (r Network_Storage_Schedule) Filter(filter string) Network_Storage_Schedule {
+func (r Network_Storage_Schedule) Filter(filter interface{}) Network_Storage_Schedule {
 	r.Options.Filter = filter
 	return r
 }
@@ -10609,7 +10609,7 @@ func (r Network_Storage_Schedule_Property_Type) Mask(mask string) Network_Storag
 	return r
 }
 
-func (r Network_Storage_Schedule_Property_Type) Filter(filter string) Network_Storage_Schedule_Property_Type {
+func (r Network_Storage_Schedule_Property_Type) Filter(filter interface{}) Network_Storage_Schedule_Property_Type {
 	r.Options.Filter = filter
 	return r
 }
@@ -10660,7 +10660,7 @@ func (r Network_Subnet) Mask(mask string) Network_Subnet {
 	return r
 }
 
-func (r Network_Subnet) Filter(filter string) Network_Subnet {
+func (r Network_Subnet) Filter(filter interface{}) Network_Subnet {
 	r.Options.Filter = filter
 	return r
 }
@@ -11039,7 +11039,7 @@ func (r Network_Subnet_IpAddress) Mask(mask string) Network_Subnet_IpAddress {
 	return r
 }
 
-func (r Network_Subnet_IpAddress) Filter(filter string) Network_Subnet_IpAddress {
+func (r Network_Subnet_IpAddress) Filter(filter interface{}) Network_Subnet_IpAddress {
 	r.Options.Filter = filter
 	return r
 }
@@ -11327,7 +11327,7 @@ func (r Network_Subnet_IpAddress_Global) Mask(mask string) Network_Subnet_IpAddr
 	return r
 }
 
-func (r Network_Subnet_IpAddress_Global) Filter(filter string) Network_Subnet_IpAddress_Global {
+func (r Network_Subnet_IpAddress_Global) Filter(filter interface{}) Network_Subnet_IpAddress_Global {
 	r.Options.Filter = filter
 	return r
 }
@@ -11417,7 +11417,7 @@ func (r Network_Subnet_Registration) Mask(mask string) Network_Subnet_Registrati
 	return r
 }
 
-func (r Network_Subnet_Registration) Filter(filter string) Network_Subnet_Registration {
+func (r Network_Subnet_Registration) Filter(filter interface{}) Network_Subnet_Registration {
 	r.Options.Filter = filter
 	return r
 }
@@ -11552,7 +11552,7 @@ func (r Network_Subnet_Registration_Details) Mask(mask string) Network_Subnet_Re
 	return r
 }
 
-func (r Network_Subnet_Registration_Details) Filter(filter string) Network_Subnet_Registration_Details {
+func (r Network_Subnet_Registration_Details) Filter(filter interface{}) Network_Subnet_Registration_Details {
 	r.Options.Filter = filter
 	return r
 }
@@ -11628,7 +11628,7 @@ func (r Network_Subnet_Registration_Status) Mask(mask string) Network_Subnet_Reg
 	return r
 }
 
-func (r Network_Subnet_Registration_Status) Filter(filter string) Network_Subnet_Registration_Status {
+func (r Network_Subnet_Registration_Status) Filter(filter interface{}) Network_Subnet_Registration_Status {
 	r.Options.Filter = filter
 	return r
 }
@@ -11681,7 +11681,7 @@ func (r Network_Subnet_Rwhois_Data) Mask(mask string) Network_Subnet_Rwhois_Data
 	return r
 }
 
-func (r Network_Subnet_Rwhois_Data) Filter(filter string) Network_Subnet_Rwhois_Data {
+func (r Network_Subnet_Rwhois_Data) Filter(filter interface{}) Network_Subnet_Rwhois_Data {
 	r.Options.Filter = filter
 	return r
 }
@@ -11754,7 +11754,7 @@ func (r Network_Subnet_Swip_Transaction) Mask(mask string) Network_Subnet_Swip_T
 	return r
 }
 
-func (r Network_Subnet_Swip_Transaction) Filter(filter string) Network_Subnet_Swip_Transaction {
+func (r Network_Subnet_Swip_Transaction) Filter(filter interface{}) Network_Subnet_Swip_Transaction {
 	r.Options.Filter = filter
 	return r
 }
@@ -11847,7 +11847,7 @@ func (r Network_TippingPointReporting) Mask(mask string) Network_TippingPointRep
 	return r
 }
 
-func (r Network_TippingPointReporting) Filter(filter string) Network_TippingPointReporting {
+func (r Network_TippingPointReporting) Filter(filter interface{}) Network_TippingPointReporting {
 	r.Options.Filter = filter
 	return r
 }
@@ -11953,7 +11953,7 @@ func (r Network_Tunnel_Module_Context) Mask(mask string) Network_Tunnel_Module_C
 	return r
 }
 
-func (r Network_Tunnel_Module_Context) Filter(filter string) Network_Tunnel_Module_Context {
+func (r Network_Tunnel_Module_Context) Filter(filter interface{}) Network_Tunnel_Module_Context {
 	r.Options.Filter = filter
 	return r
 }
@@ -12357,7 +12357,7 @@ func (r Network_Vlan) Mask(mask string) Network_Vlan {
 	return r
 }
 
-func (r Network_Vlan) Filter(filter string) Network_Vlan {
+func (r Network_Vlan) Filter(filter interface{}) Network_Vlan {
 	r.Options.Filter = filter
 	return r
 }
@@ -12721,7 +12721,7 @@ func (r Network_Vlan_Firewall) Mask(mask string) Network_Vlan_Firewall {
 	return r
 }
 
-func (r Network_Vlan_Firewall) Filter(filter string) Network_Vlan_Firewall {
+func (r Network_Vlan_Firewall) Filter(filter interface{}) Network_Vlan_Firewall {
 	r.Options.Filter = filter
 	return r
 }
@@ -12850,7 +12850,7 @@ func (r Network_Vlan_Type) Mask(mask string) Network_Vlan_Type {
 	return r
 }
 
-func (r Network_Vlan_Type) Filter(filter string) Network_Vlan_Type {
+func (r Network_Vlan_Type) Filter(filter interface{}) Network_Vlan_Type {
 	r.Options.Filter = filter
 	return r
 }

--- a/services/notification.go
+++ b/services/notification.go
@@ -53,7 +53,7 @@ func (r Notification) Mask(mask string) Notification {
 	return r
 }
 
-func (r Notification) Filter(filter string) Notification {
+func (r Notification) Filter(filter interface{}) Notification {
 	r.Options.Filter = filter
 	return r
 }
@@ -116,7 +116,7 @@ func (r Notification_Mobile) Mask(mask string) Notification_Mobile {
 	return r
 }
 
-func (r Notification_Mobile) Filter(filter string) Notification_Mobile {
+func (r Notification_Mobile) Filter(filter interface{}) Notification_Mobile {
 	r.Options.Filter = filter
 	return r
 }
@@ -190,7 +190,7 @@ func (r Notification_Occurrence_Event) Mask(mask string) Notification_Occurrence
 	return r
 }
 
-func (r Notification_Occurrence_Event) Filter(filter string) Notification_Occurrence_Event {
+func (r Notification_Occurrence_Event) Filter(filter interface{}) Notification_Occurrence_Event {
 	r.Options.Filter = filter
 	return r
 }
@@ -334,7 +334,7 @@ func (r Notification_Occurrence_User) Mask(mask string) Notification_Occurrence_
 	return r
 }
 
-func (r Notification_Occurrence_User) Filter(filter string) Notification_Occurrence_User {
+func (r Notification_Occurrence_User) Filter(filter interface{}) Notification_Occurrence_User {
 	r.Options.Filter = filter
 	return r
 }
@@ -417,7 +417,7 @@ func (r Notification_User_Subscriber) Mask(mask string) Notification_User_Subscr
 	return r
 }
 
-func (r Notification_User_Subscriber) Filter(filter string) Notification_User_Subscriber {
+func (r Notification_User_Subscriber) Filter(filter interface{}) Notification_User_Subscriber {
 	r.Options.Filter = filter
 	return r
 }
@@ -550,7 +550,7 @@ func (r Notification_User_Subscriber_Billing) Mask(mask string) Notification_Use
 	return r
 }
 
-func (r Notification_User_Subscriber_Billing) Filter(filter string) Notification_User_Subscriber_Billing {
+func (r Notification_User_Subscriber_Billing) Filter(filter interface{}) Notification_User_Subscriber_Billing {
 	r.Options.Filter = filter
 	return r
 }
@@ -683,7 +683,7 @@ func (r Notification_User_Subscriber_Mobile) Mask(mask string) Notification_User
 	return r
 }
 
-func (r Notification_User_Subscriber_Mobile) Filter(filter string) Notification_User_Subscriber_Mobile {
+func (r Notification_User_Subscriber_Mobile) Filter(filter interface{}) Notification_User_Subscriber_Mobile {
 	r.Options.Filter = filter
 	return r
 }
@@ -832,7 +832,7 @@ func (r Notification_User_Subscriber_Preference) Mask(mask string) Notification_
 	return r
 }
 
-func (r Notification_User_Subscriber_Preference) Filter(filter string) Notification_User_Subscriber_Preference {
+func (r Notification_User_Subscriber_Preference) Filter(filter interface{}) Notification_User_Subscriber_Preference {
 	r.Options.Filter = filter
 	return r
 }

--- a/services/product.go
+++ b/services/product.go
@@ -53,7 +53,7 @@ func (r Product_Item_Category) Mask(mask string) Product_Item_Category {
 	return r
 }
 
-func (r Product_Item_Category) Filter(filter string) Product_Item_Category {
+func (r Product_Item_Category) Filter(filter interface{}) Product_Item_Category {
 	r.Options.Filter = filter
 	return r
 }
@@ -119,7 +119,7 @@ func (r Product_Item_Category) GetObject() (resp datatypes.Product_Item_Category
 	return
 }
 
-// Retrieve Any unique options associated with an itme category.
+// Retrieve Any unique options associated with an item category.
 func (r Product_Item_Category) GetOrderOptions() (resp []datatypes.Product_Item_Category_Order_Option_Type, err error) {
 	err = r.Session.DoRequest("SoftLayer_Product_Item_Category", "getOrderOptions", nil, &r.Options, &resp)
 	return
@@ -206,7 +206,7 @@ func (r Product_Item_Category_Group) Mask(mask string) Product_Item_Category_Gro
 	return r
 }
 
-func (r Product_Item_Category_Group) Filter(filter string) Product_Item_Category_Group {
+func (r Product_Item_Category_Group) Filter(filter interface{}) Product_Item_Category_Group {
 	r.Options.Filter = filter
 	return r
 }
@@ -251,7 +251,7 @@ func (r Product_Item_Policy_Assignment) Mask(mask string) Product_Item_Policy_As
 	return r
 }
 
-func (r Product_Item_Policy_Assignment) Filter(filter string) Product_Item_Policy_Assignment {
+func (r Product_Item_Policy_Assignment) Filter(filter interface{}) Product_Item_Policy_Assignment {
 	r.Options.Filter = filter
 	return r
 }
@@ -323,7 +323,7 @@ func (r Product_Item_Price) Mask(mask string) Product_Item_Price {
 	return r
 }
 
-func (r Product_Item_Price) Filter(filter string) Product_Item_Price {
+func (r Product_Item_Price) Filter(filter interface{}) Product_Item_Price {
 	r.Options.Filter = filter
 	return r
 }
@@ -480,7 +480,7 @@ func (r Product_Item_Price_Premium) Mask(mask string) Product_Item_Price_Premium
 	return r
 }
 
-func (r Product_Item_Price_Premium) Filter(filter string) Product_Item_Price_Premium {
+func (r Product_Item_Price_Premium) Filter(filter interface{}) Product_Item_Price_Premium {
 	r.Options.Filter = filter
 	return r
 }
@@ -543,7 +543,7 @@ func (r Product_Order) Mask(mask string) Product_Order {
 	return r
 }
 
-func (r Product_Order) Filter(filter string) Product_Order {
+func (r Product_Order) Filter(filter interface{}) Product_Order {
 	r.Options.Filter = filter
 	return r
 }
@@ -1140,7 +1140,7 @@ func (r Product_Package) Mask(mask string) Product_Package {
 	return r
 }
 
-func (r Product_Package) Filter(filter string) Product_Package {
+func (r Product_Package) Filter(filter interface{}) Product_Package {
 	r.Options.Filter = filter
 	return r
 }
@@ -1578,7 +1578,7 @@ func (r Product_Package_Preset) Mask(mask string) Product_Package_Preset {
 	return r
 }
 
-func (r Product_Package_Preset) Filter(filter string) Product_Package_Preset {
+func (r Product_Package_Preset) Filter(filter interface{}) Product_Package_Preset {
 	r.Options.Filter = filter
 	return r
 }
@@ -1695,7 +1695,7 @@ func (r Product_Package_Server) Mask(mask string) Product_Package_Server {
 	return r
 }
 
-func (r Product_Package_Server) Filter(filter string) Product_Package_Server {
+func (r Product_Package_Server) Filter(filter interface{}) Product_Package_Server {
 	r.Options.Filter = filter
 	return r
 }
@@ -1776,7 +1776,7 @@ func (r Product_Package_Server_Option) Mask(mask string) Product_Package_Server_
 	return r
 }
 
-func (r Product_Package_Server_Option) Filter(filter string) Product_Package_Server_Option {
+func (r Product_Package_Server_Option) Filter(filter interface{}) Product_Package_Server_Option {
 	r.Options.Filter = filter
 	return r
 }
@@ -1836,7 +1836,7 @@ func (r Product_Package_Type) Mask(mask string) Product_Package_Type {
 	return r
 }
 
-func (r Product_Package_Type) Filter(filter string) Product_Package_Type {
+func (r Product_Package_Type) Filter(filter interface{}) Product_Package_Type {
 	r.Options.Filter = filter
 	return r
 }
@@ -1893,7 +1893,7 @@ func (r Product_Upgrade_Request) Mask(mask string) Product_Upgrade_Request {
 	return r
 }
 
-func (r Product_Upgrade_Request) Filter(filter string) Product_Upgrade_Request {
+func (r Product_Upgrade_Request) Filter(filter interface{}) Product_Upgrade_Request {
 	r.Options.Filter = filter
 	return r
 }

--- a/services/provisioning.go
+++ b/services/provisioning.go
@@ -53,7 +53,7 @@ func (r Provisioning_Hook) Mask(mask string) Provisioning_Hook {
 	return r
 }
 
-func (r Provisioning_Hook) Filter(filter string) Provisioning_Hook {
+func (r Provisioning_Hook) Filter(filter interface{}) Provisioning_Hook {
 	r.Options.Filter = filter
 	return r
 }
@@ -134,7 +134,7 @@ func (r Provisioning_Hook_Type) Mask(mask string) Provisioning_Hook_Type {
 	return r
 }
 
-func (r Provisioning_Hook_Type) Filter(filter string) Provisioning_Hook_Type {
+func (r Provisioning_Hook_Type) Filter(filter interface{}) Provisioning_Hook_Type {
 	r.Options.Filter = filter
 	return r
 }
@@ -185,7 +185,7 @@ func (r Provisioning_Maintenance_Classification) Mask(mask string) Provisioning_
 	return r
 }
 
-func (r Provisioning_Maintenance_Classification) Filter(filter string) Provisioning_Maintenance_Classification {
+func (r Provisioning_Maintenance_Classification) Filter(filter interface{}) Provisioning_Maintenance_Classification {
 	r.Options.Filter = filter
 	return r
 }
@@ -251,7 +251,7 @@ func (r Provisioning_Maintenance_Classification_Item_Category) Mask(mask string)
 	return r
 }
 
-func (r Provisioning_Maintenance_Classification_Item_Category) Filter(filter string) Provisioning_Maintenance_Classification_Item_Category {
+func (r Provisioning_Maintenance_Classification_Item_Category) Filter(filter interface{}) Provisioning_Maintenance_Classification_Item_Category {
 	r.Options.Filter = filter
 	return r
 }
@@ -302,7 +302,7 @@ func (r Provisioning_Maintenance_Slots) Mask(mask string) Provisioning_Maintenan
 	return r
 }
 
-func (r Provisioning_Maintenance_Slots) Filter(filter string) Provisioning_Maintenance_Slots {
+func (r Provisioning_Maintenance_Slots) Filter(filter interface{}) Provisioning_Maintenance_Slots {
 	r.Options.Filter = filter
 	return r
 }
@@ -347,7 +347,7 @@ func (r Provisioning_Maintenance_Ticket) Mask(mask string) Provisioning_Maintena
 	return r
 }
 
-func (r Provisioning_Maintenance_Ticket) Filter(filter string) Provisioning_Maintenance_Ticket {
+func (r Provisioning_Maintenance_Ticket) Filter(filter interface{}) Provisioning_Maintenance_Ticket {
 	r.Options.Filter = filter
 	return r
 }
@@ -410,7 +410,7 @@ func (r Provisioning_Maintenance_Window) Mask(mask string) Provisioning_Maintena
 	return r
 }
 
-func (r Provisioning_Maintenance_Window) Filter(filter string) Provisioning_Maintenance_Window {
+func (r Provisioning_Maintenance_Window) Filter(filter interface{}) Provisioning_Maintenance_Window {
 	r.Options.Filter = filter
 	return r
 }
@@ -528,7 +528,7 @@ func (r Provisioning_Version1_Transaction_Group) Mask(mask string) Provisioning_
 	return r
 }
 
-func (r Provisioning_Version1_Transaction_Group) Filter(filter string) Provisioning_Version1_Transaction_Group {
+func (r Provisioning_Version1_Transaction_Group) Filter(filter interface{}) Provisioning_Version1_Transaction_Group {
 	r.Options.Filter = filter
 	return r
 }

--- a/services/resource.go
+++ b/services/resource.go
@@ -53,7 +53,7 @@ func (r Resource_Group) Mask(mask string) Resource_Group {
 	return r
 }
 
-func (r Resource_Group) Filter(filter string) Resource_Group {
+func (r Resource_Group) Filter(filter interface{}) Resource_Group {
 	r.Options.Filter = filter
 	return r
 }
@@ -155,7 +155,7 @@ func (r Resource_Group_Template) Mask(mask string) Resource_Group_Template {
 	return r
 }
 
-func (r Resource_Group_Template) Filter(filter string) Resource_Group_Template {
+func (r Resource_Group_Template) Filter(filter interface{}) Resource_Group_Template {
 	r.Options.Filter = filter
 	return r
 }
@@ -224,7 +224,7 @@ func (r Resource_Metadata) Mask(mask string) Resource_Metadata {
 	return r
 }
 
-func (r Resource_Metadata) Filter(filter string) Resource_Metadata {
+func (r Resource_Metadata) Filter(filter interface{}) Resource_Metadata {
 	r.Options.Filter = filter
 	return r
 }

--- a/services/sales.go
+++ b/services/sales.go
@@ -53,7 +53,7 @@ func (r Sales_Presale_Event) Mask(mask string) Sales_Presale_Event {
 	return r
 }
 
-func (r Sales_Presale_Event) Filter(filter string) Sales_Presale_Event {
+func (r Sales_Presale_Event) Filter(filter interface{}) Sales_Presale_Event {
 	r.Options.Filter = filter
 	return r
 }

--- a/services/scale.go
+++ b/services/scale.go
@@ -53,7 +53,7 @@ func (r Scale_Asset) Mask(mask string) Scale_Asset {
 	return r
 }
 
-func (r Scale_Asset) Filter(filter string) Scale_Asset {
+func (r Scale_Asset) Filter(filter interface{}) Scale_Asset {
 	r.Options.Filter = filter
 	return r
 }
@@ -110,7 +110,7 @@ func (r Scale_Asset_Hardware) Mask(mask string) Scale_Asset_Hardware {
 	return r
 }
 
-func (r Scale_Asset_Hardware) Filter(filter string) Scale_Asset_Hardware {
+func (r Scale_Asset_Hardware) Filter(filter interface{}) Scale_Asset_Hardware {
 	r.Options.Filter = filter
 	return r
 }
@@ -188,7 +188,7 @@ func (r Scale_Asset_Virtual_Guest) Mask(mask string) Scale_Asset_Virtual_Guest {
 	return r
 }
 
-func (r Scale_Asset_Virtual_Guest) Filter(filter string) Scale_Asset_Virtual_Guest {
+func (r Scale_Asset_Virtual_Guest) Filter(filter interface{}) Scale_Asset_Virtual_Guest {
 	r.Options.Filter = filter
 	return r
 }
@@ -266,7 +266,7 @@ func (r Scale_Group) Mask(mask string) Scale_Group {
 	return r
 }
 
-func (r Scale_Group) Filter(filter string) Scale_Group {
+func (r Scale_Group) Filter(filter interface{}) Scale_Group {
 	r.Options.Filter = filter
 	return r
 }
@@ -445,7 +445,7 @@ func (r Scale_Group_Status) Mask(mask string) Scale_Group_Status {
 	return r
 }
 
-func (r Scale_Group_Status) Filter(filter string) Scale_Group_Status {
+func (r Scale_Group_Status) Filter(filter interface{}) Scale_Group_Status {
 	r.Options.Filter = filter
 	return r
 }
@@ -496,7 +496,7 @@ func (r Scale_LoadBalancer) Mask(mask string) Scale_LoadBalancer {
 	return r
 }
 
-func (r Scale_LoadBalancer) Filter(filter string) Scale_LoadBalancer {
+func (r Scale_LoadBalancer) Filter(filter interface{}) Scale_LoadBalancer {
 	r.Options.Filter = filter
 	return r
 }
@@ -613,7 +613,7 @@ func (r Scale_Member) Mask(mask string) Scale_Member {
 	return r
 }
 
-func (r Scale_Member) Filter(filter string) Scale_Member {
+func (r Scale_Member) Filter(filter interface{}) Scale_Member {
 	r.Options.Filter = filter
 	return r
 }
@@ -670,7 +670,7 @@ func (r Scale_Member_Virtual_Guest) Mask(mask string) Scale_Member_Virtual_Guest
 	return r
 }
 
-func (r Scale_Member_Virtual_Guest) Filter(filter string) Scale_Member_Virtual_Guest {
+func (r Scale_Member_Virtual_Guest) Filter(filter interface{}) Scale_Member_Virtual_Guest {
 	r.Options.Filter = filter
 	return r
 }
@@ -739,7 +739,7 @@ func (r Scale_Network_Vlan) Mask(mask string) Scale_Network_Vlan {
 	return r
 }
 
-func (r Scale_Network_Vlan) Filter(filter string) Scale_Network_Vlan {
+func (r Scale_Network_Vlan) Filter(filter interface{}) Scale_Network_Vlan {
 	r.Options.Filter = filter
 	return r
 }
@@ -811,7 +811,7 @@ func (r Scale_Policy) Mask(mask string) Scale_Policy {
 	return r
 }
 
-func (r Scale_Policy) Filter(filter string) Scale_Policy {
+func (r Scale_Policy) Filter(filter interface{}) Scale_Policy {
 	r.Options.Filter = filter
 	return r
 }
@@ -928,7 +928,7 @@ func (r Scale_Policy_Action) Mask(mask string) Scale_Policy_Action {
 	return r
 }
 
-func (r Scale_Policy_Action) Filter(filter string) Scale_Policy_Action {
+func (r Scale_Policy_Action) Filter(filter interface{}) Scale_Policy_Action {
 	r.Options.Filter = filter
 	return r
 }
@@ -1000,7 +1000,7 @@ func (r Scale_Policy_Action_Scale) Mask(mask string) Scale_Policy_Action_Scale {
 	return r
 }
 
-func (r Scale_Policy_Action_Scale) Filter(filter string) Scale_Policy_Action_Scale {
+func (r Scale_Policy_Action_Scale) Filter(filter interface{}) Scale_Policy_Action_Scale {
 	r.Options.Filter = filter
 	return r
 }
@@ -1081,7 +1081,7 @@ func (r Scale_Policy_Action_Type) Mask(mask string) Scale_Policy_Action_Type {
 	return r
 }
 
-func (r Scale_Policy_Action_Type) Filter(filter string) Scale_Policy_Action_Type {
+func (r Scale_Policy_Action_Type) Filter(filter interface{}) Scale_Policy_Action_Type {
 	r.Options.Filter = filter
 	return r
 }
@@ -1132,7 +1132,7 @@ func (r Scale_Policy_Trigger) Mask(mask string) Scale_Policy_Trigger {
 	return r
 }
 
-func (r Scale_Policy_Trigger) Filter(filter string) Scale_Policy_Trigger {
+func (r Scale_Policy_Trigger) Filter(filter interface{}) Scale_Policy_Trigger {
 	r.Options.Filter = filter
 	return r
 }
@@ -1213,7 +1213,7 @@ func (r Scale_Policy_Trigger_OneTime) Mask(mask string) Scale_Policy_Trigger_One
 	return r
 }
 
-func (r Scale_Policy_Trigger_OneTime) Filter(filter string) Scale_Policy_Trigger_OneTime {
+func (r Scale_Policy_Trigger_OneTime) Filter(filter interface{}) Scale_Policy_Trigger_OneTime {
 	r.Options.Filter = filter
 	return r
 }
@@ -1294,7 +1294,7 @@ func (r Scale_Policy_Trigger_Repeating) Mask(mask string) Scale_Policy_Trigger_R
 	return r
 }
 
-func (r Scale_Policy_Trigger_Repeating) Filter(filter string) Scale_Policy_Trigger_Repeating {
+func (r Scale_Policy_Trigger_Repeating) Filter(filter interface{}) Scale_Policy_Trigger_Repeating {
 	r.Options.Filter = filter
 	return r
 }
@@ -1385,7 +1385,7 @@ func (r Scale_Policy_Trigger_ResourceUse) Mask(mask string) Scale_Policy_Trigger
 	return r
 }
 
-func (r Scale_Policy_Trigger_ResourceUse) Filter(filter string) Scale_Policy_Trigger_ResourceUse {
+func (r Scale_Policy_Trigger_ResourceUse) Filter(filter interface{}) Scale_Policy_Trigger_ResourceUse {
 	r.Options.Filter = filter
 	return r
 }
@@ -1472,7 +1472,7 @@ func (r Scale_Policy_Trigger_ResourceUse_Watch) Mask(mask string) Scale_Policy_T
 	return r
 }
 
-func (r Scale_Policy_Trigger_ResourceUse_Watch) Filter(filter string) Scale_Policy_Trigger_ResourceUse_Watch {
+func (r Scale_Policy_Trigger_ResourceUse_Watch) Filter(filter interface{}) Scale_Policy_Trigger_ResourceUse_Watch {
 	r.Options.Filter = filter
 	return r
 }
@@ -1565,7 +1565,7 @@ func (r Scale_Policy_Trigger_Type) Mask(mask string) Scale_Policy_Trigger_Type {
 	return r
 }
 
-func (r Scale_Policy_Trigger_Type) Filter(filter string) Scale_Policy_Trigger_Type {
+func (r Scale_Policy_Trigger_Type) Filter(filter interface{}) Scale_Policy_Trigger_Type {
 	r.Options.Filter = filter
 	return r
 }
@@ -1616,7 +1616,7 @@ func (r Scale_Termination_Policy) Mask(mask string) Scale_Termination_Policy {
 	return r
 }
 
-func (r Scale_Termination_Policy) Filter(filter string) Scale_Termination_Policy {
+func (r Scale_Termination_Policy) Filter(filter interface{}) Scale_Termination_Policy {
 	r.Options.Filter = filter
 	return r
 }

--- a/services/search.go
+++ b/services/search.go
@@ -53,7 +53,7 @@ func (r Search) Mask(mask string) Search {
 	return r
 }
 
-func (r Search) Filter(filter string) Search {
+func (r Search) Filter(filter interface{}) Search {
 	r.Options.Filter = filter
 	return r
 }

--- a/services/security.go
+++ b/services/security.go
@@ -53,7 +53,7 @@ func (r Security_Certificate) Mask(mask string) Security_Certificate {
 	return r
 }
 
-func (r Security_Certificate) Filter(filter string) Security_Certificate {
+func (r Security_Certificate) Filter(filter interface{}) Security_Certificate {
 	r.Options.Filter = filter
 	return r
 }
@@ -151,7 +151,7 @@ func (r Security_Certificate_Request) Mask(mask string) Security_Certificate_Req
 	return r
 }
 
-func (r Security_Certificate_Request) Filter(filter string) Security_Certificate_Request {
+func (r Security_Certificate_Request) Filter(filter interface{}) Security_Certificate_Request {
 	r.Options.Filter = filter
 	return r
 }
@@ -285,7 +285,7 @@ func (r Security_Certificate_Request_ServerType) Mask(mask string) Security_Cert
 	return r
 }
 
-func (r Security_Certificate_Request_ServerType) Filter(filter string) Security_Certificate_Request_ServerType {
+func (r Security_Certificate_Request_ServerType) Filter(filter interface{}) Security_Certificate_Request_ServerType {
 	r.Options.Filter = filter
 	return r
 }
@@ -336,7 +336,7 @@ func (r Security_Certificate_Request_Status) Mask(mask string) Security_Certific
 	return r
 }
 
-func (r Security_Certificate_Request_Status) Filter(filter string) Security_Certificate_Request_Status {
+func (r Security_Certificate_Request_Status) Filter(filter interface{}) Security_Certificate_Request_Status {
 	r.Options.Filter = filter
 	return r
 }
@@ -387,7 +387,7 @@ func (r Security_Ssh_Key) Mask(mask string) Security_Ssh_Key {
 	return r
 }
 
-func (r Security_Ssh_Key) Filter(filter string) Security_Ssh_Key {
+func (r Security_Ssh_Key) Filter(filter interface{}) Security_Ssh_Key {
 	r.Options.Filter = filter
 	return r
 }

--- a/services/software.go
+++ b/services/software.go
@@ -53,7 +53,7 @@ func (r Software_AccountLicense) Mask(mask string) Software_AccountLicense {
 	return r
 }
 
-func (r Software_AccountLicense) Filter(filter string) Software_AccountLicense {
+func (r Software_AccountLicense) Filter(filter interface{}) Software_AccountLicense {
 	r.Options.Filter = filter
 	return r
 }
@@ -126,7 +126,7 @@ func (r Software_Component) Mask(mask string) Software_Component {
 	return r
 }
 
-func (r Software_Component) Filter(filter string) Software_Component {
+func (r Software_Component) Filter(filter interface{}) Software_Component {
 	r.Options.Filter = filter
 	return r
 }
@@ -233,7 +233,7 @@ func (r Software_Component_AntivirusSpyware) Mask(mask string) Software_Componen
 	return r
 }
 
-func (r Software_Component_AntivirusSpyware) Filter(filter string) Software_Component_AntivirusSpyware {
+func (r Software_Component_AntivirusSpyware) Filter(filter interface{}) Software_Component_AntivirusSpyware {
 	r.Options.Filter = filter
 	return r
 }
@@ -353,7 +353,7 @@ func (r Software_Component_HostIps) Mask(mask string) Software_Component_HostIps
 	return r
 }
 
-func (r Software_Component_HostIps) Filter(filter string) Software_Component_HostIps {
+func (r Software_Component_HostIps) Filter(filter interface{}) Software_Component_HostIps {
 	r.Options.Filter = filter
 	return r
 }
@@ -479,7 +479,7 @@ func (r Software_Component_Password) Mask(mask string) Software_Component_Passwo
 	return r
 }
 
-func (r Software_Component_Password) Filter(filter string) Software_Component_Password {
+func (r Software_Component_Password) Filter(filter interface{}) Software_Component_Password {
 	r.Options.Filter = filter
 	return r
 }
@@ -591,7 +591,7 @@ func (r Software_Description) Mask(mask string) Software_Description {
 	return r
 }
 
-func (r Software_Description) Filter(filter string) Software_Description {
+func (r Software_Description) Filter(filter interface{}) Software_Description {
 	r.Options.Filter = filter
 	return r
 }
@@ -720,7 +720,7 @@ func (r Software_VirtualLicense) Mask(mask string) Software_VirtualLicense {
 	return r
 }
 
-func (r Software_VirtualLicense) Filter(filter string) Software_VirtualLicense {
+func (r Software_VirtualLicense) Filter(filter interface{}) Software_VirtualLicense {
 	r.Options.Filter = filter
 	return r
 }

--- a/services/survey.go
+++ b/services/survey.go
@@ -53,7 +53,7 @@ func (r Survey) Mask(mask string) Survey {
 	return r
 }
 
-func (r Survey) Filter(filter string) Survey {
+func (r Survey) Filter(filter interface{}) Survey {
 	r.Options.Filter = filter
 	return r
 }

--- a/services/tag.go
+++ b/services/tag.go
@@ -53,7 +53,7 @@ func (r Tag) Mask(mask string) Tag {
 	return r
 }
 
-func (r Tag) Filter(filter string) Tag {
+func (r Tag) Filter(filter interface{}) Tag {
 	r.Options.Filter = filter
 	return r
 }

--- a/services/ticket.go
+++ b/services/ticket.go
@@ -55,7 +55,7 @@ func (r Ticket) Mask(mask string) Ticket {
 	return r
 }
 
-func (r Ticket) Filter(filter string) Ticket {
+func (r Ticket) Filter(filter interface{}) Ticket {
 	r.Options.Filter = filter
 	return r
 }
@@ -615,7 +615,7 @@ func (r Ticket_Attachment_File) Mask(mask string) Ticket_Attachment_File {
 	return r
 }
 
-func (r Ticket_Attachment_File) Filter(filter string) Ticket_Attachment_File {
+func (r Ticket_Attachment_File) Filter(filter interface{}) Ticket_Attachment_File {
 	r.Options.Filter = filter
 	return r
 }
@@ -678,7 +678,7 @@ func (r Ticket_Priority) Mask(mask string) Ticket_Priority {
 	return r
 }
 
-func (r Ticket_Priority) Filter(filter string) Ticket_Priority {
+func (r Ticket_Priority) Filter(filter interface{}) Ticket_Priority {
 	r.Options.Filter = filter
 	return r
 }
@@ -723,7 +723,7 @@ func (r Ticket_Subject) Mask(mask string) Ticket_Subject {
 	return r
 }
 
-func (r Ticket_Subject) Filter(filter string) Ticket_Subject {
+func (r Ticket_Subject) Filter(filter interface{}) Ticket_Subject {
 	r.Options.Filter = filter
 	return r
 }
@@ -786,7 +786,7 @@ func (r Ticket_Survey) Mask(mask string) Ticket_Survey {
 	return r
 }
 
-func (r Ticket_Survey) Filter(filter string) Ticket_Survey {
+func (r Ticket_Survey) Filter(filter interface{}) Ticket_Survey {
 	r.Options.Filter = filter
 	return r
 }
@@ -847,7 +847,7 @@ func (r Ticket_Update_Employee) Mask(mask string) Ticket_Update_Employee {
 	return r
 }
 
-func (r Ticket_Update_Employee) Filter(filter string) Ticket_Update_Employee {
+func (r Ticket_Update_Employee) Filter(filter interface{}) Ticket_Update_Employee {
 	r.Options.Filter = filter
 	return r
 }

--- a/services/user.go
+++ b/services/user.go
@@ -53,7 +53,7 @@ func (r User_Customer) Mask(mask string) User_Customer {
 	return r
 }
 
-func (r User_Customer) Filter(filter string) User_Customer {
+func (r User_Customer) Filter(filter interface{}) User_Customer {
 	r.Options.Filter = filter
 	return r
 }
@@ -451,6 +451,12 @@ func (r User_Customer) GetNotificationSubscribers() (resp []datatypes.Notificati
 // getObject retrieves the SoftLayer_User_Customer object whose ID number corresponds to the ID number of the init parameter passed to the SoftLayer_User_Customer service. You can only retrieve users that are assigned to the customer account belonging to the user making the API call.
 func (r User_Customer) GetObject() (resp datatypes.User_Customer, err error) {
 	err = r.Session.DoRequest("SoftLayer_User_Customer", "getObject", nil, &r.Options, &resp)
+	return
+}
+
+// This API returns a SoftLayer_Container_User_Customer_OpenIdConnect_MigrationState object containing the necessary information to determine what migration state the user is in. If the account is not OpenIdConnect authenticated, then an exception is thrown.
+func (r User_Customer) GetOpenIdConnectMigrationState() (resp datatypes.Container_User_Customer_OpenIdConnect_MigrationState, err error) {
+	err = r.Session.DoRequest("SoftLayer_User_Customer", "getOpenIdConnectMigrationState", nil, &r.Options, &resp)
 	return
 }
 
@@ -1082,7 +1088,7 @@ func (r User_Customer_ApiAuthentication) Mask(mask string) User_Customer_ApiAuth
 	return r
 }
 
-func (r User_Customer_ApiAuthentication) Filter(filter string) User_Customer_ApiAuthentication {
+func (r User_Customer_ApiAuthentication) Filter(filter interface{}) User_Customer_ApiAuthentication {
 	r.Options.Filter = filter
 	return r
 }
@@ -1142,7 +1148,7 @@ func (r User_Customer_CustomerPermission_Permission) Mask(mask string) User_Cust
 	return r
 }
 
-func (r User_Customer_CustomerPermission_Permission) Filter(filter string) User_Customer_CustomerPermission_Permission {
+func (r User_Customer_CustomerPermission_Permission) Filter(filter interface{}) User_Customer_CustomerPermission_Permission {
 	r.Options.Filter = filter
 	return r
 }
@@ -1193,7 +1199,7 @@ func (r User_Customer_External_Binding) Mask(mask string) User_Customer_External
 	return r
 }
 
-func (r User_Customer_External_Binding) Filter(filter string) User_Customer_External_Binding {
+func (r User_Customer_External_Binding) Filter(filter interface{}) User_Customer_External_Binding {
 	r.Options.Filter = filter
 	return r
 }
@@ -1314,7 +1320,7 @@ func (r User_Customer_External_Binding_Phone) Mask(mask string) User_Customer_Ex
 	return r
 }
 
-func (r User_Customer_External_Binding_Phone) Filter(filter string) User_Customer_External_Binding_Phone {
+func (r User_Customer_External_Binding_Phone) Filter(filter interface{}) User_Customer_External_Binding_Phone {
 	r.Options.Filter = filter
 	return r
 }
@@ -1531,7 +1537,7 @@ func (r User_Customer_External_Binding_Totp) Mask(mask string) User_Customer_Ext
 	return r
 }
 
-func (r User_Customer_External_Binding_Totp) Filter(filter string) User_Customer_External_Binding_Totp {
+func (r User_Customer_External_Binding_Totp) Filter(filter interface{}) User_Customer_External_Binding_Totp {
 	r.Options.Filter = filter
 	return r
 }
@@ -1668,7 +1674,7 @@ func (r User_Customer_External_Binding_Vendor) Mask(mask string) User_Customer_E
 	return r
 }
 
-func (r User_Customer_External_Binding_Vendor) Filter(filter string) User_Customer_External_Binding_Vendor {
+func (r User_Customer_External_Binding_Vendor) Filter(filter interface{}) User_Customer_External_Binding_Vendor {
 	r.Options.Filter = filter
 	return r
 }
@@ -1731,7 +1737,7 @@ func (r User_Customer_External_Binding_Verisign) Mask(mask string) User_Customer
 	return r
 }
 
-func (r User_Customer_External_Binding_Verisign) Filter(filter string) User_Customer_External_Binding_Verisign {
+func (r User_Customer_External_Binding_Verisign) Filter(filter interface{}) User_Customer_External_Binding_Verisign {
 	r.Options.Filter = filter
 	return r
 }
@@ -1901,7 +1907,7 @@ func (r User_Customer_Invitation) Mask(mask string) User_Customer_Invitation {
 	return r
 }
 
-func (r User_Customer_Invitation) Filter(filter string) User_Customer_Invitation {
+func (r User_Customer_Invitation) Filter(filter interface{}) User_Customer_Invitation {
 	r.Options.Filter = filter
 	return r
 }
@@ -1952,7 +1958,7 @@ func (r User_Customer_MobileDevice) Mask(mask string) User_Customer_MobileDevice
 	return r
 }
 
-func (r User_Customer_MobileDevice) Filter(filter string) User_Customer_MobileDevice {
+func (r User_Customer_MobileDevice) Filter(filter interface{}) User_Customer_MobileDevice {
 	r.Options.Filter = filter
 	return r
 }
@@ -2051,7 +2057,7 @@ func (r User_Customer_MobileDevice_OperatingSystem) Mask(mask string) User_Custo
 	return r
 }
 
-func (r User_Customer_MobileDevice_OperatingSystem) Filter(filter string) User_Customer_MobileDevice_OperatingSystem {
+func (r User_Customer_MobileDevice_OperatingSystem) Filter(filter interface{}) User_Customer_MobileDevice_OperatingSystem {
 	r.Options.Filter = filter
 	return r
 }
@@ -2102,7 +2108,7 @@ func (r User_Customer_MobileDevice_Type) Mask(mask string) User_Customer_MobileD
 	return r
 }
 
-func (r User_Customer_MobileDevice_Type) Filter(filter string) User_Customer_MobileDevice_Type {
+func (r User_Customer_MobileDevice_Type) Filter(filter interface{}) User_Customer_MobileDevice_Type {
 	r.Options.Filter = filter
 	return r
 }
@@ -2153,7 +2159,7 @@ func (r User_Customer_Notification_Hardware) Mask(mask string) User_Customer_Not
 	return r
 }
 
-func (r User_Customer_Notification_Hardware) Filter(filter string) User_Customer_Notification_Hardware {
+func (r User_Customer_Notification_Hardware) Filter(filter interface{}) User_Customer_Notification_Hardware {
 	r.Options.Filter = filter
 	return r
 }
@@ -2248,7 +2254,7 @@ func (r User_Customer_Notification_Virtual_Guest) Mask(mask string) User_Custome
 	return r
 }
 
-func (r User_Customer_Notification_Virtual_Guest) Filter(filter string) User_Customer_Notification_Virtual_Guest {
+func (r User_Customer_Notification_Virtual_Guest) Filter(filter interface{}) User_Customer_Notification_Virtual_Guest {
 	r.Options.Filter = filter
 	return r
 }
@@ -2343,7 +2349,7 @@ func (r User_Customer_OpenIdConnect) Mask(mask string) User_Customer_OpenIdConne
 	return r
 }
 
-func (r User_Customer_OpenIdConnect) Filter(filter string) User_Customer_OpenIdConnect {
+func (r User_Customer_OpenIdConnect) Filter(filter interface{}) User_Customer_OpenIdConnect {
 	r.Options.Filter = filter
 	return r
 }
@@ -2686,7 +2692,7 @@ func (r User_Customer_OpenIdConnect) GetClosedTickets() (resp []datatypes.Ticket
 	return
 }
 
-// This API gets the default for the OpenIdConnect identity that is linked from the current SoftLayer user identity. If there is no default present, the API returns null.
+// This API gets the default account for the OpenIdConnect identity that is linked to the current SoftLayer user identity. If there is no default present, the API returns null.
 func (r User_Customer_OpenIdConnect) GetDefaultAccount(providerType *string) (resp datatypes.Account, err error) {
 	params := []interface{}{
 		providerType,
@@ -2794,6 +2800,12 @@ func (r User_Customer_OpenIdConnect) GetNotificationSubscribers() (resp []dataty
 // no documentation yet
 func (r User_Customer_OpenIdConnect) GetObject() (resp datatypes.User_Customer_OpenIdConnect, err error) {
 	err = r.Session.DoRequest("SoftLayer_User_Customer_OpenIdConnect", "getObject", nil, &r.Options, &resp)
+	return
+}
+
+// This API returns a SoftLayer_Container_User_Customer_OpenIdConnect_MigrationState object containing the necessary information to determine what migration state the user is in. If the account is not OpenIdConnect authenticated, then an exception is thrown.
+func (r User_Customer_OpenIdConnect) GetOpenIdConnectMigrationState() (resp datatypes.Container_User_Customer_OpenIdConnect_MigrationState, err error) {
+	err = r.Session.DoRequest("SoftLayer_User_Customer_OpenIdConnect", "getOpenIdConnectMigrationState", nil, &r.Options, &resp)
 	return
 }
 
@@ -3301,7 +3313,7 @@ func (r User_Customer_OpenIdConnect) SamlLogout(samlResponse *string) (err error
 	return
 }
 
-// This API sets the default account for the OpenIdConnect identity that is linked from the current SoftLayer user identity.
+// An OpenIdConnect identity, for example an IBMid, can be linked or mapped to one or more individual SoftLayer users, but no more than one per account. If an OpenIdConnect identity is mapped to multiple accounts in this manner, one such account should be identified as the default account for that identity.
 func (r User_Customer_OpenIdConnect) SetDefaultAccount(providerType *string, accountId *int) (resp datatypes.Account, err error) {
 	params := []interface{}{
 		providerType,
@@ -3456,7 +3468,7 @@ func (r User_Customer_Prospect_ServiceProvider_EnrollRequest) Mask(mask string) 
 	return r
 }
 
-func (r User_Customer_Prospect_ServiceProvider_EnrollRequest) Filter(filter string) User_Customer_Prospect_ServiceProvider_EnrollRequest {
+func (r User_Customer_Prospect_ServiceProvider_EnrollRequest) Filter(filter interface{}) User_Customer_Prospect_ServiceProvider_EnrollRequest {
 	r.Options.Filter = filter
 	return r
 }
@@ -3516,7 +3528,7 @@ func (r User_Customer_Security_Answer) Mask(mask string) User_Customer_Security_
 	return r
 }
 
-func (r User_Customer_Security_Answer) Filter(filter string) User_Customer_Security_Answer {
+func (r User_Customer_Security_Answer) Filter(filter interface{}) User_Customer_Security_Answer {
 	r.Options.Filter = filter
 	return r
 }
@@ -3573,7 +3585,7 @@ func (r User_Customer_Status) Mask(mask string) User_Customer_Status {
 	return r
 }
 
-func (r User_Customer_Status) Filter(filter string) User_Customer_Status {
+func (r User_Customer_Status) Filter(filter interface{}) User_Customer_Status {
 	r.Options.Filter = filter
 	return r
 }
@@ -3624,7 +3636,7 @@ func (r User_External_Binding) Mask(mask string) User_External_Binding {
 	return r
 }
 
-func (r User_External_Binding) Filter(filter string) User_External_Binding {
+func (r User_External_Binding) Filter(filter interface{}) User_External_Binding {
 	r.Options.Filter = filter
 	return r
 }
@@ -3714,7 +3726,7 @@ func (r User_External_Binding_Vendor) Mask(mask string) User_External_Binding_Ve
 	return r
 }
 
-func (r User_External_Binding_Vendor) Filter(filter string) User_External_Binding_Vendor {
+func (r User_External_Binding_Vendor) Filter(filter interface{}) User_External_Binding_Vendor {
 	r.Options.Filter = filter
 	return r
 }
@@ -3765,7 +3777,7 @@ func (r User_Permission_Action) Mask(mask string) User_Permission_Action {
 	return r
 }
 
-func (r User_Permission_Action) Filter(filter string) User_Permission_Action {
+func (r User_Permission_Action) Filter(filter interface{}) User_Permission_Action {
 	r.Options.Filter = filter
 	return r
 }
@@ -3816,7 +3828,7 @@ func (r User_Permission_Group) Mask(mask string) User_Permission_Group {
 	return r
 }
 
-func (r User_Permission_Group) Filter(filter string) User_Permission_Group {
+func (r User_Permission_Group) Filter(filter interface{}) User_Permission_Group {
 	r.Options.Filter = filter
 	return r
 }
@@ -4009,7 +4021,7 @@ func (r User_Permission_Group_Type) Mask(mask string) User_Permission_Group_Type
 	return r
 }
 
-func (r User_Permission_Group_Type) Filter(filter string) User_Permission_Group_Type {
+func (r User_Permission_Group_Type) Filter(filter interface{}) User_Permission_Group_Type {
 	r.Options.Filter = filter
 	return r
 }
@@ -4060,7 +4072,7 @@ func (r User_Permission_Role) Mask(mask string) User_Permission_Role {
 	return r
 }
 
-func (r User_Permission_Role) Filter(filter string) User_Permission_Role {
+func (r User_Permission_Role) Filter(filter interface{}) User_Permission_Role {
 	r.Options.Filter = filter
 	return r
 }
@@ -4193,7 +4205,7 @@ func (r User_Security_Question) Mask(mask string) User_Security_Question {
 	return r
 }
 
-func (r User_Security_Question) Filter(filter string) User_Security_Question {
+func (r User_Security_Question) Filter(filter interface{}) User_Security_Question {
 	r.Options.Filter = filter
 	return r
 }

--- a/services/utility.go
+++ b/services/utility.go
@@ -52,7 +52,7 @@ func (r Utility_Network) Mask(mask string) Utility_Network {
 	return r
 }
 
-func (r Utility_Network) Filter(filter string) Utility_Network {
+func (r Utility_Network) Filter(filter interface{}) Utility_Network {
 	r.Options.Filter = filter
 	return r
 }

--- a/services/virtual.go
+++ b/services/virtual.go
@@ -55,7 +55,7 @@ func (r Virtual_Disk_Image) Mask(mask string) Virtual_Disk_Image {
 	return r
 }
 
-func (r Virtual_Disk_Image) Filter(filter string) Virtual_Disk_Image {
+func (r Virtual_Disk_Image) Filter(filter interface{}) Virtual_Disk_Image {
 	r.Options.Filter = filter
 	return r
 }
@@ -195,7 +195,7 @@ func (r Virtual_Guest) Mask(mask string) Virtual_Guest {
 	return r
 }
 
-func (r Virtual_Guest) Filter(filter string) Virtual_Guest {
+func (r Virtual_Guest) Filter(filter interface{}) Virtual_Guest {
 	r.Options.Filter = filter
 	return r
 }
@@ -1939,7 +1939,7 @@ func (r Virtual_Guest_Block_Device_Template_Group) Mask(mask string) Virtual_Gue
 	return r
 }
 
-func (r Virtual_Guest_Block_Device_Template_Group) Filter(filter string) Virtual_Guest_Block_Device_Template_Group {
+func (r Virtual_Guest_Block_Device_Template_Group) Filter(filter interface{}) Virtual_Guest_Block_Device_Template_Group {
 	r.Options.Filter = filter
 	return r
 }
@@ -2215,7 +2215,7 @@ func (r Virtual_Guest_Boot_Parameter) Mask(mask string) Virtual_Guest_Boot_Param
 	return r
 }
 
-func (r Virtual_Guest_Boot_Parameter) Filter(filter string) Virtual_Guest_Boot_Parameter {
+func (r Virtual_Guest_Boot_Parameter) Filter(filter interface{}) Virtual_Guest_Boot_Parameter {
 	r.Options.Filter = filter
 	return r
 }
@@ -2296,7 +2296,7 @@ func (r Virtual_Guest_Boot_Parameter_Type) Mask(mask string) Virtual_Guest_Boot_
 	return r
 }
 
-func (r Virtual_Guest_Boot_Parameter_Type) Filter(filter string) Virtual_Guest_Boot_Parameter_Type {
+func (r Virtual_Guest_Boot_Parameter_Type) Filter(filter interface{}) Virtual_Guest_Boot_Parameter_Type {
 	r.Options.Filter = filter
 	return r
 }
@@ -2349,7 +2349,7 @@ func (r Virtual_Guest_Network_Component) Mask(mask string) Virtual_Guest_Network
 	return r
 }
 
-func (r Virtual_Guest_Network_Component) Filter(filter string) Virtual_Guest_Network_Component {
+func (r Virtual_Guest_Network_Component) Filter(filter interface{}) Virtual_Guest_Network_Component {
 	r.Options.Filter = filter
 	return r
 }
@@ -2478,7 +2478,7 @@ func (r Virtual_Host) Mask(mask string) Virtual_Host {
 	return r
 }
 
-func (r Virtual_Host) Filter(filter string) Virtual_Host {
+func (r Virtual_Host) Filter(filter interface{}) Virtual_Host {
 	r.Options.Filter = filter
 	return r
 }
@@ -2640,7 +2640,7 @@ func (r Virtual_Storage_Repository) Mask(mask string) Virtual_Storage_Repository
 	return r
 }
 
-func (r Virtual_Storage_Repository) Filter(filter string) Virtual_Storage_Repository {
+func (r Virtual_Storage_Repository) Filter(filter interface{}) Virtual_Storage_Repository {
 	r.Options.Filter = filter
 	return r
 }

--- a/session/rest.go
+++ b/session/rest.go
@@ -137,7 +137,7 @@ func encodeQuery(opts *sl.Options) string {
 	}
 
 	if opts.Filter != "" {
-		query.Add("objectFilter", opts.Filter)
+		query.Add("objectFilter", opts.Filter.(string))
 	}
 
 	// resultLimit=<offset>,<limit>

--- a/sl/options.go
+++ b/sl/options.go
@@ -21,7 +21,7 @@ package sl
 type Options struct {
 	Id     *int
 	Mask   string
-	Filter string
+	Filter interface{}
 	Limit  *int
 	Offset *int
 }

--- a/tools/loadmeta.go
+++ b/tools/loadmeta.go
@@ -137,7 +137,7 @@ import (
 		return r
 	}
 
-	func (r {{$base}}) Filter(filter string) {{$base}} {
+	func (r {{$base}}) Filter(filter interface{}) {{$base}} {
 		r.Options.Filter = filter
 		return r
 	}


### PR DESCRIPTION
- `Options.Filter` changed to interface{}.
- `services.*.Filter()` changed to accept interface{}
- filter `Build()` methods output map[string]interface{}
- Check type of filter (string or map[string]interface when building XMLRPC payload and handle accordingly.

Possibly more that needs to be done.  Just wanted to demonstrate that this might work and not break the public interface?  (unless an existing client is storing a filter in a variable...).