### PR TITLE
Minor transport related fixes

### DIFF
--- a/session/rest.go
+++ b/session/rest.go
@@ -167,7 +167,7 @@ func makeHTTPRequest(session *Session, path string, requestType string, requestB
 	} else {
 		url = url + session.Endpoint
 	}
-	url = url + "/" + path
+	url = fmt.Sprintf("%s/%s", strings.TrimRight(url, "/"), path)
 	req, err := http.NewRequest(requestType, url, requestBody)
 	if err != nil {
 		return nil, 0, err

--- a/session/xmlrpc.go
+++ b/session/xmlrpc.go
@@ -165,8 +165,7 @@ func (x *XmlRpcTransport) DoRequest(
 	}
 
 	err := client.Call(method, params, pResult)
-	if err != nil {
-		xmlRpcError := err.(*xmlrpc.XmlRpcError)
+	if xmlRpcError, ok := err.(*xmlrpc.XmlRpcError); ok {
 		return sl.Error{
 			StatusCode: xmlRpcError.HttpStatusCode,
 			Exception:  xmlRpcError.Code,
@@ -174,5 +173,5 @@ func (x *XmlRpcTransport) DoRequest(
 		}
 	}
 
-	return nil
+	return err
 }

--- a/session/xmlrpc.go
+++ b/session/xmlrpc.go
@@ -65,7 +65,7 @@ func (x *XmlRpcTransport) DoRequest(
 	pResult interface{},
 ) error {
 
-	serviceUrl := fmt.Sprintf("%s/%s", sess.Endpoint, service)
+	serviceUrl := fmt.Sprintf("%s/%s", strings.TrimRight(sess.Endpoint, "/"), service)
 	client, ok := xmlRpcClients[serviceUrl]
 	if !ok {
 		var roundTripper http.RoundTripper


### PR DESCRIPTION
* Remove trailing slash from endpoint_url
* Handle failed type assertion and just return original error