### PR TITLE
Conditional removal of omitempty tag

### DIFF
--- a/datatypes/dns.go
+++ b/datatypes/dns.go
@@ -40,7 +40,7 @@ type Dns_Domain struct {
 	ResourceRecordCount *uint `json:"resourceRecordCount,omitempty" xmlrpc:"resourceRecordCount,omitempty"`
 
 	// The individual records contained within a domain record. These include but are not limited to A, AAAA, MX, CTYPE, SPF and TXT records.
-	ResourceRecords []Dns_Domain_ResourceRecord `json:"resourceRecords,omitempty" xmlrpc:"resourceRecords,omitempty"`
+	ResourceRecords []Dns_Domain_ResourceRecord `json:"resourceRecords" xmlrpc:"resourceRecords"`
 
 	// The secondary DNS record that defines this domain as being managed through zone transfers.
 	Secondary *Dns_Secondary `json:"secondary,omitempty" xmlrpc:"secondary,omitempty"`

--- a/tools/loadmeta.go
+++ b/tools/loadmeta.go
@@ -79,6 +79,7 @@ var fMap = template.FuncMap{
 	"titleCase":       strings.Title,       // TitleCase the argument
 	"desnake":         Desnake,             // Remove '_' from Snake_Case
 	"goDoc":           GoDoc,               // Format a go doc string
+	"tags":            Tags,                // Remove omitempty tags if required
 	"phraseMethodArg": phraseMethodArg,     // Get proper phrase for method argument
 }
 
@@ -94,7 +95,7 @@ type {{.Name|removePrefix}} struct {
 
 	{{$base := .Name}}{{range .Properties}}{{.Doc|goDoc}}
 	{{.Name|titleCase}} {{if .TypeArray}}[]{{else}}*{{end}}{{convertType .Type "datatypes" $base .Name}}`+
-	"`json:\"{{.Name}},omitempty\" xmlrpc:\"{{.Name}},omitempty\"`"+`
+	"`json:\"{{.Name|tags}}\" xmlrpc:\"{{.Name|tags}}\"`"+`
 
 	{{end}}
 }
@@ -320,6 +321,18 @@ func GoDoc(args ...interface{}) string {
 	}
 
 	return "// " + strings.Replace(s, "\n", "\n// ", -1)
+}
+
+// Remove omitempty tags if required
+func Tags(args ...interface{}) string {
+	n := args[0].(string)
+
+	switch n {
+	case "resourceRecords":
+		return n
+	default:
+		return n + ",omitempty"
+	}
 }
 
 // private


### PR DESCRIPTION
Some struct fields may need the `omitempty` tag to be absent so as to send empty value such as `"resourceRecords" : []`
`Tags` function checks if `omitempty` is needed.

This will resolve https://github.com/softlayer/terraform-provider-softlayer/issues/61