### PR TITLE
Filter price list for CPU by DedicatedAccountHostOnlyFlag  in UpgradeVirtualGuest helper function.

### DIFF
--- a/helpers/product/product.go
+++ b/helpers/product/product.go
@@ -137,6 +137,12 @@ func SelectProductPricesByCategory(
 		forPublicNetwork = public[0]
 	}
 
+	// Check type of cores
+	forPublicCores := true
+	if len(public) > 0 {
+		forPublicCores = public[1]
+	}
+
 	// Filter product items based on sets of category codes and capacity numbers
 	prices := []datatypes.Product_Item_Price{}
 	priceCheck := map[string]bool{}
@@ -164,7 +170,7 @@ func SelectProductPricesByCategory(
 				// Logic taken from softlayer-python @ http://bit.ly/2bN9Gbu
 				switch categoryCode {
 				case CPUCategoryCode:
-					if forPublicNetwork == isPrivate {
+					if forPublicCores == isPrivate {
 						continue
 					}
 				case NICSpeedCategoryCode:

--- a/helpers/product/product.go
+++ b/helpers/product/product.go
@@ -139,7 +139,7 @@ func SelectProductPricesByCategory(
 
 	// Check type of cores
 	forPublicCores := true
-	if len(public) > 0 {
+	if len(public) > 1 {
 		forPublicCores = public[1]
 	}
 

--- a/helpers/product/product.go
+++ b/helpers/product/product.go
@@ -126,7 +126,7 @@ func GetPackageProducts(
 // For example, these are the options to specify an upgrade to 8 cpus and 32
 // GB or memory:
 // {"guest_core": 8.0, "ram": 32.0}
-// Public[0] checks type of network.
+// public[0] checks type of network.
 // public[1] checks type of cores.
 
 func SelectProductPricesByCategory(

--- a/helpers/product/product.go
+++ b/helpers/product/product.go
@@ -126,6 +126,9 @@ func GetPackageProducts(
 // For example, these are the options to specify an upgrade to 8 cpus and 32
 // GB or memory:
 // {"guest_core": 8.0, "ram": 32.0}
+// Public[0] checks type of network.
+// public[1] checks type of cores.
+
 func SelectProductPricesByCategory(
 	productItems []datatypes.Product_Item,
 	options map[string]float64,

--- a/helpers/virtual/virtual.go
+++ b/helpers/virtual/virtual.go
@@ -38,14 +38,15 @@ func UpgradeVirtualGuest(
 	when ...time.Time,
 ) (datatypes.Container_Product_Order_Receipt, error) {
 
-	if guest.PrivateNetworkOnlyFlag == nil {
+	if guest.PrivateNetworkOnlyFlag == nil || guest.DedicatedAccountHostOnlyFlag == nil {
 		service := services.GetVirtualGuestService(sess)
-		guestForFlag, err := service.Id(*guest.Id).Mask("privateNetworkOnlyFlag").GetObject()
+		guestForFlag, err := service.Id(*guest.Id).Mask("privateNetworkOnlyFlag,dedicatedAccountHostOnlyFlag").GetObject()
 		if err != nil {
 			return datatypes.Container_Product_Order_Receipt{}, err
 		}
 
 		guest.PrivateNetworkOnlyFlag = guestForFlag.PrivateNetworkOnlyFlag
+		guest.DedicatedAccountHostOnlyFlag = guestForFlag.DedicatedAccountHostOnlyFlag
 	}
 
 	pkg, err := product.GetPackageByType(sess, "VIRTUAL_SERVER_INSTANCE")
@@ -58,7 +59,7 @@ func UpgradeVirtualGuest(
 		return datatypes.Container_Product_Order_Receipt{}, err
 	}
 
-	prices := product.SelectProductPricesByCategory(productItems, options, !*guest.PrivateNetworkOnlyFlag)
+	prices := product.SelectProductPricesByCategory(productItems, options, !*guest.PrivateNetworkOnlyFlag, !*guest.DedicatedAccountHostOnlyFlag)
 
 	upgradeTime := time.Now().UTC().Format(time.RFC3339)
 	if len(when) > 0 {


### PR DESCRIPTION
Use public[1] as a filter for CPU price lists in product.SelectProductPricesByCategory function. 
Pass `!*guest.DedicatedAccountHostOnlyFlag` when virtual.UpgradeVirtualGuest invokes product.SelectProductPricesByCategory.
This fix will resolve the issue #34 and support cpu upgrade.