### PR TITLE
Change example and godoc for exported name GetObject

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ sess := session.New(username, apikey)
 accountService := services.GetAccountService(sess)
 
 // 3. Invoke a method:
-account, err := accountService.getObject()
+account, err := accountService.GetObject()
 ```
 
 [More examples](https://github.com/softlayer/softlayer-go/tree/master/examples)

--- a/services/account.go
+++ b/services/account.go
@@ -1246,7 +1246,7 @@ func (r Account) GetNotificationSubscribers() (resp []datatypes.Notification_Sub
 	return
 }
 
-// getObject retrieves the SoftLayer_Account object whose ID number corresponds to the ID number of the init parameter passed to the SoftLayer_Account service. You can only retrieve the account that your portal user is assigned to.
+// GetObject retrieves the SoftLayer_Account object whose ID number corresponds to the ID number of the init parameter passed to the SoftLayer_Account service. You can only retrieve the account that your portal user is assigned to.
 func (r Account) GetObject() (resp datatypes.Account, err error) {
 	err = r.Session.DoRequest("SoftLayer_Account", "getObject", nil, &r.Options, &resp)
 	return


### PR DESCRIPTION
Example in README.md uses an unexported name `getObject`, which is a compile time error and the build error provides a useful suggestion to use `GetObject` instead:

`accountService.getObject undefined (type services.Account has no field or method
 getObject, but does have GetObject)`


PR fixes the README.md example, and also updates the GoDoc `services/account.go:GetObject`.