### PR TITLE
Changed the default session timeout from 60 to 120.

### DIFF
--- a/session/session.go
+++ b/session/session.go
@@ -66,7 +66,7 @@ type TransportHandler interface {
 		pResult interface{}) error
 }
 
-const DefaultTimeout = time.Second * 60
+const DefaultTimeout = time.Second * 120
 
 // Session stores the information required for communication with the SoftLayer
 // API


### PR DESCRIPTION
Increased the default session timeout from 60 to 120 to support softlayer APIs with xml-rpc. This fix is related to the issue #47.