### PR TITLE
Add retry logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,16 @@ import "github.com/softlayer/softlayer-go/session"
 session.Logger = log.New(os.Stderr, "[CUSTOMIZED] ", log.LstdFlags)
 ```
 
+You can also tell the session to retry the api requests if there is a timeout error:
+
+```go
+// Specify how many times to retry the request, the request timeout, and how much time to wait
+// between retries.
+services.GetVirtualGuestService(
+	sess.SetTimeout(900).SetRetries(2).SetRetryWait(3)
+).GetObject(...)
+```
+
 ### Password-based authentication
 
 Password-based authentication (via requesting a token from the API) is

--- a/session/session.go
+++ b/session/session.go
@@ -43,7 +43,7 @@ func init() {
 // is provided.
 const DefaultEndpoint = "https://api.softlayer.com/rest/v3"
 
-// TransportHandler
+// TransportHandler interface for the protocol-specific handling of API requests.
 type TransportHandler interface {
 	// DoRequest is the protocol-specific handler for making API requests.
 	//
@@ -238,11 +238,43 @@ func (r *Session) DoRequest(service string, method string, args []interface{}, o
 	return r.TransportHandler.DoRequest(r, service, method, args, options, pResult)
 }
 
-// AppendUserAgent allows higher level application to identify themselves by appending to the useragent string
+// SetTimeout creates a copy of the session and sets the passed timeout into it
+// before returning it.
+func (r *Session) SetTimeout(timeout time.Duration) *Session {
+	var s Session
+	s = *r
+	s.Timeout = timeout
+
+	return &s
+}
+
+// SetRetries creates a copy of the session and sets the passed retries into it
+// before returning it.
+func (r *Session) SetRetries(retries int) *Session {
+	var s Session
+	s = *r
+	s.Retries = retries
+
+	return &s
+}
+
+// SetRetryWait creates a copy of the session and sets the passed retryWait into it
+// before returning it.
+func (r *Session) SetRetryWait(retryWait time.Duration) *Session {
+	var s Session
+	s = *r
+	s.RetryWait = retryWait
+
+	return &s
+}
+
+// AppendUserAgent allows higher level application to identify themselves by
+// appending to the useragent string
 func (r *Session) AppendUserAgent(agent string) {
 	if r.userAgent == "" {
 		r.userAgent = getDefaultUserAgent()
 	}
+
 	if agent != "" {
 		r.userAgent += " " + agent
 	}
@@ -271,14 +303,6 @@ func getDefaultTransport(endpointURL string) TransportHandler {
 	return transportHandler
 }
 
-<<<<<<< HEAD
-func getDefaultUserAgent() string {
-	return fmt.Sprintf("softlayer-go/%s (%s;%s;%s)", sl.Version.String(),
-		runtime.Version(),
-		runtime.GOARCH,
-		runtime.GOOS,
-	)
-=======
 func isTimeout(err error) bool {
 	if slErr, ok := err.(sl.Error); ok {
 		switch slErr.StatusCode {
@@ -300,5 +324,12 @@ func isTimeout(err error) bool {
 	}
 
 	return false
->>>>>>> 022e5f1... Add retry logic
+}
+
+func getDefaultUserAgent() string {
+	return fmt.Sprintf("softlayer-go/%s (%s;%s;%s)", sl.Version.String(),
+		runtime.Version(),
+		runtime.GOARCH,
+		runtime.GOOS,
+	)
 }

--- a/session/xmlrpc.go
+++ b/session/xmlrpc.go
@@ -19,9 +19,11 @@ package session
 import (
 	"encoding/json"
 	"fmt"
+	"math/rand"
 	"net/http"
 	"net/http/httputil"
 	"strings"
+	"time"
 
 	"github.com/renier/xmlrpc"
 	"github.com/softlayer/softlayer-go/sl"
@@ -164,12 +166,45 @@ func (x *XmlRpcTransport) DoRequest(
 		params = append(params, arg)
 	}
 
-	err = client.Call(method, params, pResult)
+	retries := sess.Retries
+	if retries < 2 {
+		err = client.Call(method, params, pResult)
+	} else {
+		wait := sess.RetryWait
+		if wait == 0 {
+			wait = DefaultRetryWait
+		}
+
+		err = makeXmlRequest(retries, wait, client, method, params, pResult)
+	}
+
 	if xmlRpcError, ok := err.(*xmlrpc.XmlRpcError); ok {
-		return sl.Error{
+		err = sl.Error{
 			StatusCode: xmlRpcError.HttpStatusCode,
 			Exception:  xmlRpcError.Code.(string),
 			Message:    xmlRpcError.Err,
+		}
+	}
+
+	return err
+}
+
+func makeXmlRequest(
+	retries int, wait time.Duration, client *xmlrpc.Client,
+	method string, params []interface{}, pResult interface{}) error {
+
+	err := client.Call(method, params, pResult)
+	if err != nil {
+		if !isTimeout(err) {
+			return err
+		}
+
+		if retries--; retries > 0 {
+			jitter := time.Duration(rand.Int63n(int64(wait)))
+			wait = wait + jitter/2
+			time.Sleep(wait)
+			return makeXmlRequest(
+				retries, wait, client, method, params, pResult)
 		}
 	}
 


### PR DESCRIPTION
Added a method to figure out if we have a network timeout error.
By default, API operations are only done once. To activate retries, the
session.Retries can be set to a number greater than 1.
If the transport error is not detected to be a timeout error, a retry
is not attempted. This is important, as retrying anything other than a
clear network timeout error can be expensive.

The retry logic uses an exponential backoff (with a random jitter) for each subsequent try.

@jsloyer @sykesm @gvirtanen @piecafe Appreciate your comments/reactions to this as well.
