### PR TITLE
Use a productItem.KeyName to check a cpu type.

### DIFF
--- a/helpers/product/product.go
+++ b/helpers/product/product.go
@@ -150,7 +150,7 @@ func SelectProductPricesByCategory(
 	prices := []datatypes.Product_Item_Price{}
 	priceCheck := map[string]bool{}
 	for _, productItem := range productItems {
-		isPrivate := strings.HasPrefix(sl.Get(productItem.Description, "").(string), "Private")
+		isPrivate := strings.Contains(sl.Get(productItem.KeyName, "").(string), "PRIVATE")
 		isPublic := strings.Contains(sl.Get(productItem.Description, "Public").(string), "Public")
 		for _, category := range productItem.Prices[0].Categories {
 			for categoryCode, capacity := range options {


### PR DESCRIPTION
SoftLayer `private VM` name has been changed to `dedicated VM`. Price item description of private cores was also updated to `Dedicated`. For example, `"description": "56 x 2.0 GHz Cores (Private)",` has changed to "description": "56 x 2.0 GHz Cores (Dedicated)". 
`SelectProductPricesByCategory` function filters Cores using description and it generates errors because the description has changed. This fix uses keyName instead of description for core type filtering. It will resolve the terraform-softlayer-provider issue https://github.com/softlayer/terraform-provider-softlayer/issues/157 