### PR TITLE
Add feature of customize logger

### DIFF
--- a/session/rest.go
+++ b/session/rest.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"net/http"
 	"net/url"
 	"reflect"
@@ -197,8 +196,8 @@ func makeHTTPRequest(session *Session, path string, requestType string, requestB
 	req.URL.RawQuery = encodeQuery(options)
 
 	if session.Debug {
-		log.Println("[DEBUG] Request URL: ", requestType, req.URL)
-		log.Println("[DEBUG] Parameters: ", requestBody.String())
+		session.Logger.Println("[DEBUG] Request URL: ", requestType, req.URL)
+		session.Logger.Println("[DEBUG] Parameters: ", requestBody.String())
 	}
 
 	resp, err := client.Do(req)
@@ -214,7 +213,7 @@ func makeHTTPRequest(session *Session, path string, requestType string, requestB
 	}
 
 	if session.Debug {
-		log.Println("[DEBUG] Response: ", string(responseBody))
+		session.Logger.Println("[DEBUG] Response: ", string(responseBody))
 	}
 	return responseBody, resp.StatusCode, nil
 }

--- a/session/rest.go
+++ b/session/rest.go
@@ -169,6 +169,7 @@ func encodeQuery(opts *sl.Options) string {
 }
 
 func makeHTTPRequest(session *Session, path string, requestType string, requestBody *bytes.Buffer, options *sl.Options) ([]byte, int, error) {
+	log := session.Logger
 	client := http.DefaultClient
 	client.Timeout = DefaultTimeout
 	if session.Timeout != 0 {
@@ -196,8 +197,8 @@ func makeHTTPRequest(session *Session, path string, requestType string, requestB
 	req.URL.RawQuery = encodeQuery(options)
 
 	if session.Debug {
-		session.Logger.Println("[DEBUG] Request URL: ", requestType, req.URL)
-		session.Logger.Println("[DEBUG] Parameters: ", requestBody.String())
+		log.Println("[DEBUG] Request URL: ", requestType, req.URL)
+		log.Println("[DEBUG] Parameters: ", requestBody.String())
 	}
 
 	resp, err := client.Do(req)
@@ -213,7 +214,7 @@ func makeHTTPRequest(session *Session, path string, requestType string, requestB
 	}
 
 	if session.Debug {
-		session.Logger.Println("[DEBUG] Response: ", string(responseBody))
+		log.Println("[DEBUG] Response: ", string(responseBody))
 	}
 	return responseBody, resp.StatusCode, nil
 }

--- a/session/session.go
+++ b/session/session.go
@@ -18,14 +18,13 @@ package session
 
 import (
 	"fmt"
+	"github.com/softlayer/softlayer-go/config"
+	"github.com/softlayer/softlayer-go/sl"
 	"log"
 	"os"
 	"os/user"
 	"strings"
 	"time"
-
-	"github.com/softlayer/softlayer-go/config"
-	"github.com/softlayer/softlayer-go/sl"
 )
 
 // DefaultEndpoint is the default endpoint for API calls, when no override
@@ -99,6 +98,11 @@ type Session struct {
 	// session. Requests that take longer that the specified timeout
 	// will result in an error.
 	Timeout time.Duration
+
+	// Logger specified a string format of log information.
+	// A Logger represents an active logging object that
+	// generates lines of output to an io.Writer.
+	Logger *log.Logger
 }
 
 // New creates and returns a pointer to a new session object.  It takes up to
@@ -176,10 +180,13 @@ func New(args ...interface{}) *Session {
 		endpointURL = DefaultEndpoint
 	}
 
+	logger := log.New(os.Stderr, "", log.LstdFlags)
+
 	sess := &Session{
 		UserName: values[keys["username"]],
 		APIKey:   values[keys["api_key"]],
 		Endpoint: endpointURL,
+		Logger:   logger,
 	}
 
 	timeout := values[keys["timeout"]]

--- a/session/session.go
+++ b/session/session.go
@@ -18,13 +18,14 @@ package session
 
 import (
 	"fmt"
-	"github.com/softlayer/softlayer-go/config"
-	"github.com/softlayer/softlayer-go/sl"
 	"log"
 	"os"
 	"os/user"
 	"strings"
 	"time"
+
+	"github.com/softlayer/softlayer-go/config"
+	"github.com/softlayer/softlayer-go/sl"
 )
 
 // DefaultEndpoint is the default endpoint for API calls, when no override
@@ -180,13 +181,11 @@ func New(args ...interface{}) *Session {
 		endpointURL = DefaultEndpoint
 	}
 
-	logger := log.New(os.Stderr, "", log.LstdFlags)
-
 	sess := &Session{
 		UserName: values[keys["username"]],
 		APIKey:   values[keys["api_key"]],
 		Endpoint: endpointURL,
-		Logger:   logger,
+		Logger:   log.New(os.Stderr, "", log.LstdFlags),
 	}
 
 	timeout := values[keys["timeout"]]


### PR DESCRIPTION
Hi, this PR focus on issue [#61 ](https://github.com/softlayer/softlayer-go/issues/61#event-1178040680)

The design of customizing logger is relied on the official library `log`.  The use of this library replaces original log that uses default official logger in lib `log`. The new logger binds on our session instance, and is called by `session.Logger.Println("[DEBUG] Response: ", string(responseBody))`. 

```
logger := log.New(os.Stderr, "", log.LstdFlags)
 sess := &Session{
  		UserName: values[keys["username"]],
  		APIKey:   values[keys["api_key"]],
  		Endpoint: endpointURL,
 		Logger:   logger,
  }
```
So you can re-bind a logger onto Session instance `sess` if you have customize logger settings such as output file path, string format, etc.

```
anotherLogger := log.New(os.Stdout, "TEST", log.Ldate | log.Ltime)
session := session.New(username, password, apiEndpoint)
session.Logger = anotherLogger
```

The `anotherLogger` below least can be customized as your wish.

@renier So, How about the design of logger. It uses the official library and compatible with original usage.
Thank you~