### PR TITLE
Allow users to set their own custom logger for the sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,14 @@ To enable debug output:
 session.Debug = true
 ```
 
+By default, the debug output is sent to standard output. You can customize this by setting up your own logger:
+
+```go
+import "github.com/softlayer/softlayer-go/session"
+
+session.Logger = log.New(os.Stderr, "[CUSTOMIZED] ", log.LstdFlags)
+```
+
 ### Password-based authentication
 
 Password-based authentication (via requesting a token from the API) is

--- a/session/rest.go
+++ b/session/rest.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"net/http"
 	"net/url"
 	"reflect"
@@ -170,6 +169,7 @@ func encodeQuery(opts *sl.Options) string {
 }
 
 func makeHTTPRequest(session *Session, path string, requestType string, requestBody *bytes.Buffer, options *sl.Options) ([]byte, int, error) {
+	log := Logger
 	client := http.DefaultClient
 	client.Timeout = DefaultTimeout
 	if session.Timeout != 0 {

--- a/session/session.go
+++ b/session/session.go
@@ -28,6 +28,14 @@ import (
 	"github.com/softlayer/softlayer-go/sl"
 )
 
+// Logger is the logger used by the SoftLayer session package. Can be overridden by the user.
+var Logger *log.Logger
+
+func init() {
+	// initialize the logger used by the session package.
+	Logger = log.New(os.Stderr, "", log.LstdFlags)
+}
+
 // DefaultEndpoint is the default endpoint for API calls, when no override
 // is provided.
 const DefaultEndpoint = "https://api.softlayer.com/rest/v3"

--- a/session/xmlrpc.go
+++ b/session/xmlrpc.go
@@ -19,7 +19,6 @@ package session
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 	"net/http"
 	"net/http/httputil"
 	"strings"
@@ -32,6 +31,7 @@ import (
 type debugRoundTripper struct{}
 
 func (mrt debugRoundTripper) RoundTrip(request *http.Request) (*http.Response, error) {
+	log := Logger
 	log.Println("->>>Request:")
 	dumpedReq, _ := httputil.DumpRequestOut(request, true)
 	log.Println(string(dumpedReq))


### PR DESCRIPTION
Closes #62 

Allows user to specify their own logger for the library's debug output.

Example:

```go
session.Logger = log.New(os.Stderr, "[CUSTOMIZED] ", log.LstdFlags)
sess := session.New()
sess.Debug = true
service := services.GetVirtualGuestBlockDeviceTemplateGroupService(sess)
service.GetPublicImages()
// ...
```

Prints out something like:

```
[CUSTOMIZED] 2017/08/03 17:09:38 [DEBUG] Request URL:  GET https://api.softlayer.com/rest/v3/SoftLayer_Virtual_Guest_Block_Device_Template_Group/getPublicImages.json
```