### PR TITLE
`make generate` to update datatypes and services

### DIFF
--- a/datatypes/account.go
+++ b/datatypes/account.go
@@ -248,6 +248,9 @@ type Account struct {
 	// This field is deprecated and should not be used.
 	BlueIdAuthenticationRequiredFlag *bool `json:"blueIdAuthenticationRequiredFlag,omitempty" xmlrpc:"blueIdAuthenticationRequiredFlag,omitempty"`
 
+	// The Bluemix account link associated with this SoftLayer account, if one exists.
+	BluemixAccountLink *Account_Link_Bluemix `json:"bluemixAccountLink,omitempty" xmlrpc:"bluemixAccountLink,omitempty"`
+
 	// Returns true if this account is linked to IBM Bluemix, false if not.
 	BluemixLinkedFlag *bool `json:"bluemixLinkedFlag,omitempty" xmlrpc:"bluemixLinkedFlag,omitempty"`
 
@@ -1890,6 +1893,11 @@ type Account_External_Setup struct {
 
 // no documentation yet
 type Account_Historical_Report struct {
+	Entity
+}
+
+// no documentation yet
+type Account_Internal_Ibm struct {
 	Entity
 }
 

--- a/datatypes/configuration.go
+++ b/datatypes/configuration.go
@@ -121,6 +121,9 @@ type Configuration_Storage_Group_Template_Group struct {
 	// Comma delimited integers of drive indexes for the array. This can also be the string 'all' to specify all drives in the server
 	HardDrivesString *string `json:"hardDrivesString,omitempty" xmlrpc:"hardDrivesString,omitempty"`
 
+	// Comma delimited integers of drive indexes for hot spares on the array.
+	HotSpareDrivesString *string `json:"hotSpareDrivesString,omitempty" xmlrpc:"hotSpareDrivesString,omitempty"`
+
 	// The order of the arrays in the template.
 	OrderIndex *int `json:"orderIndex,omitempty" xmlrpc:"orderIndex,omitempty"`
 

--- a/datatypes/container.go
+++ b/datatypes/container.go
@@ -186,6 +186,80 @@ type Container_Account_Historical_Summary_Uptime struct {
 	Container_Account_Historical_Summary
 }
 
+// Contains data required to both request a new IaaS account for active IBM employees and review pending requests. Fields used exclusively in the review process are scrubbed of user input.
+type Container_Account_Internal_Ibm_Request struct {
+	Entity
+
+	// Purpose of the internal IBM account chosen from the list of available
+	AccountType *string `json:"accountType,omitempty" xmlrpc:"accountType,omitempty"`
+
+	// If no address information is available in BluePages, will use this
+	Address1 *string `json:"address1,omitempty" xmlrpc:"address1,omitempty"`
+
+	// If no address information is available in BluePages, will use this
+	Address2 *string `json:"address2,omitempty" xmlrpc:"address2,omitempty"`
+
+	// If no address information is available in BluePages, will use this
+	City *string `json:"city,omitempty" xmlrpc:"city,omitempty"`
+
+	// Name of the company displayed on the IaaS account
+	CompanyName *string `json:"companyName,omitempty" xmlrpc:"companyName,omitempty"`
+
+	// If no address information is available in BluePages, will use this
+	Country *string `json:"country,omitempty" xmlrpc:"country,omitempty"`
+
+	// True if the request has been denied by either the IaaS team or the
+	DeniedFlag *bool `json:"deniedFlag,omitempty" xmlrpc:"deniedFlag,omitempty"`
+
+	// Department within the division which will be changed during cost recovery.
+	DepartmentCode *string `json:"departmentCode,omitempty" xmlrpc:"departmentCode,omitempty"`
+
+	// Division code used for cost recovery. This field is populated
+	DivisionCode *string `json:"divisionCode,omitempty" xmlrpc:"divisionCode,omitempty"`
+
+	// Country assigned to the division for cost recovery. This field is populated
+	DivisionCountry *string `json:"divisionCountry,omitempty" xmlrpc:"divisionCountry,omitempty"`
+
+	// Account owner's IBM email address. Must be a discoverable email
+	EmailAddress *string `json:"emailAddress,omitempty" xmlrpc:"emailAddress,omitempty"`
+
+	// Applicant's first name, as provided by IBM BluePages API.
+	FirstName *string `json:"firstName,omitempty" xmlrpc:"firstName,omitempty"`
+
+	// Applicant's last name, as provided by IBM BluePages API.
+	LastName *string `json:"lastName,omitempty" xmlrpc:"lastName,omitempty"`
+
+	// APPROVED if the request has been approved by the first-line manager,
+	ManagerApprovalStatus *string `json:"managerApprovalStatus,omitempty" xmlrpc:"managerApprovalStatus,omitempty"`
+
+	// True for accounts intended to be multi-tenant and false otherwise
+	MultiTenantFlag *bool `json:"multiTenantFlag,omitempty" xmlrpc:"multiTenantFlag,omitempty"`
+
+	// Account owner's primary phone number. If no phone number is available
+	OfficePhone *string `json:"officePhone,omitempty" xmlrpc:"officePhone,omitempty"`
+
+	// Bluemix PaaS 32 digit hexadecimal account id being automatically linked
+	PaasAccountId *string `json:"paasAccountId,omitempty" xmlrpc:"paasAccountId,omitempty"`
+
+	// If no address information is available in BluePages, will use this
+	PostalCode *string `json:"postalCode,omitempty" xmlrpc:"postalCode,omitempty"`
+
+	// Stated purpose of the new account this request would create
+	Purpose *string `json:"purpose,omitempty" xmlrpc:"purpose,omitempty"`
+
+	// Division's security SME's email address, if available
+	SecuritySubjectMatterExpertEmail *string `json:"securitySubjectMatterExpertEmail,omitempty" xmlrpc:"securitySubjectMatterExpertEmail,omitempty"`
+
+	// Division's security SME's name, if available
+	SecuritySubjectMatterExpertName *string `json:"securitySubjectMatterExpertName,omitempty" xmlrpc:"securitySubjectMatterExpertName,omitempty"`
+
+	// Division's security SME's phone, if available
+	SecuritySubjectMatterExpertPhone *string `json:"securitySubjectMatterExpertPhone,omitempty" xmlrpc:"securitySubjectMatterExpertPhone,omitempty"`
+
+	// If no address information is available in BluePages, will use this
+	State *string `json:"state,omitempty" xmlrpc:"state,omitempty"`
+}
+
 // no documentation yet
 type Container_Account_Payment_Method_CreditCard struct {
 	Entity
@@ -750,6 +824,17 @@ type Container_Collection_Locale_StateCode struct {
 	ShortName *string `json:"shortName,omitempty" xmlrpc:"shortName,omitempty"`
 }
 
+// This container is used to hold VAT information.
+type Container_Collection_Locale_VatCountryCodeAndFormat struct {
+	Entity
+
+	// no documentation yet
+	CountryCode *string `json:"countryCode,omitempty" xmlrpc:"countryCode,omitempty"`
+
+	// no documentation yet
+	Regex *string `json:"regex,omitempty" xmlrpc:"regex,omitempty"`
+}
+
 // no documentation yet
 type Container_Disk_Image_Capture_Template struct {
 	Entity
@@ -1234,6 +1319,12 @@ type Container_Hardware_Pool_Details struct {
 	Entity
 
 	// no documentation yet
+	PendingOrders *int `json:"pendingOrders,omitempty" xmlrpc:"pendingOrders,omitempty"`
+
+	// no documentation yet
+	PendingTransactions *int `json:"pendingTransactions,omitempty" xmlrpc:"pendingTransactions,omitempty"`
+
+	// no documentation yet
 	PoolDescription *string `json:"poolDescription,omitempty" xmlrpc:"poolDescription,omitempty"`
 
 	// no documentation yet
@@ -1264,6 +1355,9 @@ type Container_Hardware_Pool_Details struct {
 // no documentation yet
 type Container_Hardware_Pool_Details_Router struct {
 	Entity
+
+	// no documentation yet
+	PoolThreshold *int `json:"poolThreshold,omitempty" xmlrpc:"poolThreshold,omitempty"`
 
 	// no documentation yet
 	RouterId *int `json:"routerId,omitempty" xmlrpc:"routerId,omitempty"`
@@ -1600,6 +1694,9 @@ type Container_Network_CdnMarketplace_Configuration_Input struct {
 	BucketName *string `json:"bucketName,omitempty" xmlrpc:"bucketName,omitempty"`
 
 	// no documentation yet
+	CacheKeyQueryRule *string `json:"cacheKeyQueryRule,omitempty" xmlrpc:"cacheKeyQueryRule,omitempty"`
+
+	// no documentation yet
 	CertificateType *string `json:"certificateType,omitempty" xmlrpc:"certificateType,omitempty"`
 
 	// no documentation yet
@@ -1662,6 +1759,9 @@ type Container_Network_CdnMarketplace_Configuration_Mapping struct {
 	BucketName *string `json:"bucketName,omitempty" xmlrpc:"bucketName,omitempty"`
 
 	// no documentation yet
+	CacheKeyQueryRule *string `json:"cacheKeyQueryRule,omitempty" xmlrpc:"cacheKeyQueryRule,omitempty"`
+
+	// no documentation yet
 	CertificateType *string `json:"certificateType,omitempty" xmlrpc:"certificateType,omitempty"`
 
 	// no documentation yet
@@ -1719,6 +1819,9 @@ type Container_Network_CdnMarketplace_Configuration_Mapping_Path struct {
 
 	// no documentation yet
 	BucketName *string `json:"bucketName,omitempty" xmlrpc:"bucketName,omitempty"`
+
+	// no documentation yet
+	CacheKeyQueryRule *string `json:"cacheKeyQueryRule,omitempty" xmlrpc:"cacheKeyQueryRule,omitempty"`
 
 	// no documentation yet
 	FileExtension *string `json:"fileExtension,omitempty" xmlrpc:"fileExtension,omitempty"`
@@ -3590,6 +3693,9 @@ type Container_Product_Order_Network_LoadBalancer_AsAService struct {
 
 	// The [[SoftLayer_Network_Subnet]]s where this Load Balancer will be provisioned.
 	Subnets []Network_Subnet `json:"subnets,omitempty" xmlrpc:"subnets,omitempty"`
+
+	// Specify if this load balancer uses system IP pool (true, default) or customer's (null|false) public subnet to allocate IP addresses.
+	UseSystemPublicIpPool *bool `json:"useSystemPublicIpPool,omitempty" xmlrpc:"useSystemPublicIpPool,omitempty"`
 }
 
 // This is the datatype that needs to be populated and sent to SoftLayer_Product_Order::placeOrder. This datatype has everything required to place a global load balancer order with SoftLayer.

--- a/datatypes/hardware.go
+++ b/datatypes/hardware.go
@@ -741,6 +741,9 @@ type Hardware_Component struct {
 	// A count of a components sub components. Devices that are usually integrated or in some way attached to a component.
 	ChildrenCount *uint `json:"childrenCount,omitempty" xmlrpc:"childrenCount,omitempty"`
 
+	// A component's Revision.
+	ComponentRevision *string `json:"componentRevision,omitempty" xmlrpc:"componentRevision,omitempty"`
+
 	// A count of
 	DownlinkHardwareComponentCount *uint `json:"downlinkHardwareComponentCount,omitempty" xmlrpc:"downlinkHardwareComponentCount,omitempty"`
 
@@ -809,9 +812,6 @@ type Hardware_Component struct {
 
 	// A RAID controllers RAID mode.
 	RaidMode *string `json:"raidMode,omitempty" xmlrpc:"raidMode,omitempty"`
-
-	// The component revision designation.
-	Revision *Hardware_Component_Revision `json:"revision,omitempty" xmlrpc:"revision,omitempty"`
 
 	// The component serial number.
 	SerialNumber *string `json:"serialNumber,omitempty" xmlrpc:"serialNumber,omitempty"`
@@ -993,6 +993,9 @@ type Hardware_Component_Model struct {
 
 	// A count of
 	FirmwareCount *uint `json:"firmwareCount,omitempty" xmlrpc:"firmwareCount,omitempty"`
+
+	// no documentation yet
+	FirmwareQuantity *uint `json:"firmwareQuantity,omitempty" xmlrpc:"firmwareQuantity,omitempty"`
 
 	// no documentation yet
 	Firmwares []Hardware_Component_Firmware `json:"firmwares,omitempty" xmlrpc:"firmwares,omitempty"`
@@ -1388,26 +1391,6 @@ type Hardware_Component_RemoteManagement_User struct {
 
 	// The username used for this remote management command.
 	Username *string `json:"username,omitempty" xmlrpc:"username,omitempty"`
-}
-
-// no documentation yet
-type Hardware_Component_Revision struct {
-	Entity
-
-	// The Firmware installed on this record's Hardware Component.
-	Firmware *Hardware_Component_Firmware `json:"firmware,omitempty" xmlrpc:"firmware,omitempty"`
-
-	// no documentation yet
-	FirmwareVersionId *int `json:"firmwareVersionId,omitempty" xmlrpc:"firmwareVersionId,omitempty"`
-
-	// The Hardware Component this revision record applies to.
-	HardwareComponent *Hardware_Component `json:"hardwareComponent,omitempty" xmlrpc:"hardwareComponent,omitempty"`
-
-	// no documentation yet
-	HardwareComponentId *int `json:"hardwareComponentId,omitempty" xmlrpc:"hardwareComponentId,omitempty"`
-
-	// no documentation yet
-	Id *int `json:"id,omitempty" xmlrpc:"id,omitempty"`
 }
 
 // The SoftLayer_Hardware_Component_SecurityDevice is used to determine the security devices attached to the hardware component.

--- a/datatypes/locale.go
+++ b/datatypes/locale.go
@@ -64,6 +64,9 @@ type Locale_Country struct {
 
 	// States that belong to this country.
 	States []Locale_StateProvince `json:"states,omitempty" xmlrpc:"states,omitempty"`
+
+	// no documentation yet
+	VatIdRegex *string `json:"vatIdRegex,omitempty" xmlrpc:"vatIdRegex,omitempty"`
 }
 
 // This object represents a state or province for a country.

--- a/datatypes/network.go
+++ b/datatypes/network.go
@@ -2006,6 +2006,9 @@ type Network_Interconnect_Tenant struct {
 	// no documentation yet
 	DatacenterName *string `json:"datacenterName,omitempty" xmlrpc:"datacenterName,omitempty"`
 
+	// no documentation yet
+	ErrorMessage *string `json:"errorMessage,omitempty" xmlrpc:"errorMessage,omitempty"`
+
 	// The Direct Link connectivity to all SoftLayer data centers if globalRoutingFlag = 1 and local connectivity if globalRoutingFlag = 0.
 	GlobalRoutingFlag *bool `json:"globalRoutingFlag,omitempty" xmlrpc:"globalRoutingFlag,omitempty"`
 
@@ -3189,6 +3192,9 @@ type Network_SecurityGroup_OrderBinding struct {
 
 	// The unique ID for a security group, order, binding
 	Id *int `json:"id,omitempty" xmlrpc:"id,omitempty"`
+
+	// The order associated with the binding
+	Order *Billing_Order `json:"order,omitempty" xmlrpc:"order,omitempty"`
 
 	// The ID of the order associated with the security group.
 	OrderId *int `json:"orderId,omitempty" xmlrpc:"orderId,omitempty"`

--- a/services/account.go
+++ b/services/account.go
@@ -505,6 +505,12 @@ func (r Account) GetBlueIdAuthenticationRequiredFlag() (resp bool, err error) {
 	return
 }
 
+// Retrieve The Bluemix account link associated with this SoftLayer account, if one exists.
+func (r Account) GetBluemixAccountLink() (resp datatypes.Account_Link_Bluemix, err error) {
+	err = r.Session.DoRequest("SoftLayer_Account", "getBluemixAccountLink", nil, &r.Options, &resp)
+	return
+}
+
 // Retrieve Returns true if this account is linked to IBM Bluemix, false if not.
 func (r Account) GetBluemixLinkedFlag() (resp bool, err error) {
 	err = r.Session.DoRequest("SoftLayer_Account", "getBluemixLinkedFlag", nil, &r.Options, &resp)
@@ -2901,6 +2907,112 @@ func (r Account_Historical_Report) GetUrlUptimeGraphData(configurationValueId *i
 		endDate,
 	}
 	err = r.Session.DoRequest("SoftLayer_Account_Historical_Report", "getUrlUptimeGraphData", params, &r.Options, &resp)
+	return
+}
+
+// no documentation yet
+type Account_Internal_Ibm struct {
+	Session *session.Session
+	Options sl.Options
+}
+
+// GetAccountInternalIbmService returns an instance of the Account_Internal_Ibm SoftLayer service
+func GetAccountInternalIbmService(sess *session.Session) Account_Internal_Ibm {
+	return Account_Internal_Ibm{Session: sess}
+}
+
+func (r Account_Internal_Ibm) Id(id int) Account_Internal_Ibm {
+	r.Options.Id = &id
+	return r
+}
+
+func (r Account_Internal_Ibm) Mask(mask string) Account_Internal_Ibm {
+	if !strings.HasPrefix(mask, "mask[") && (strings.Contains(mask, "[") || strings.Contains(mask, ",")) {
+		mask = fmt.Sprintf("mask[%s]", mask)
+	}
+
+	r.Options.Mask = mask
+	return r
+}
+
+func (r Account_Internal_Ibm) Filter(filter string) Account_Internal_Ibm {
+	r.Options.Filter = filter
+	return r
+}
+
+func (r Account_Internal_Ibm) Limit(limit int) Account_Internal_Ibm {
+	r.Options.Limit = &limit
+	return r
+}
+
+func (r Account_Internal_Ibm) Offset(offset int) Account_Internal_Ibm {
+	r.Options.Offset = &offset
+	return r
+}
+
+// Validates request and, if the request is approved, returns a list of allowed uses for an automatically created IBMer IaaS account.
+func (r Account_Internal_Ibm) GetAccountTypes() (resp []string, err error) {
+	err = r.Session.DoRequest("SoftLayer_Account_Internal_Ibm", "getAccountTypes", nil, &r.Options, &resp)
+	return
+}
+
+// Gets the URL used to perform manager validation.
+func (r Account_Internal_Ibm) GetAuthorizationUrl(requestId *int) (resp string, err error) {
+	params := []interface{}{
+		requestId,
+	}
+	err = r.Session.DoRequest("SoftLayer_Account_Internal_Ibm", "getAuthorizationUrl", params, &r.Options, &resp)
+	return
+}
+
+// Exchanges a code for a token during manager validation.
+func (r Account_Internal_Ibm) GetEmployeeAccessToken(unverifiedAuthenticationCode *string) (resp string, err error) {
+	params := []interface{}{
+		unverifiedAuthenticationCode,
+	}
+	err = r.Session.DoRequest("SoftLayer_Account_Internal_Ibm", "getEmployeeAccessToken", params, &r.Options, &resp)
+	return
+}
+
+// After validating the requesting user through the access token, generates a container with the relevant request information and returns it.
+func (r Account_Internal_Ibm) GetManagerPreview(requestId *int, accessToken *string) (resp datatypes.Container_Account_Internal_Ibm_Request, err error) {
+	params := []interface{}{
+		requestId,
+		accessToken,
+	}
+	err = r.Session.DoRequest("SoftLayer_Account_Internal_Ibm", "getManagerPreview", params, &r.Options, &resp)
+	return
+}
+
+// Applies manager approval to a pending internal IBM account request. If cost recovery is already configured, this will create an account. If not, this will remind the internal team to configure cost recovery and create the account when possible.
+func (r Account_Internal_Ibm) ManagerApprove(requestId *int, accessToken *string) (err error) {
+	var resp datatypes.Void
+	params := []interface{}{
+		requestId,
+		accessToken,
+	}
+	err = r.Session.DoRequest("SoftLayer_Account_Internal_Ibm", "managerApprove", params, &r.Options, &resp)
+	return
+}
+
+// Denies a pending request and prevents additional requests from the same applicant for as long as the manager remains the same.
+func (r Account_Internal_Ibm) ManagerDeny(requestId *int, accessToken *string) (err error) {
+	var resp datatypes.Void
+	params := []interface{}{
+		requestId,
+		accessToken,
+	}
+	err = r.Session.DoRequest("SoftLayer_Account_Internal_Ibm", "managerDeny", params, &r.Options, &resp)
+	return
+}
+
+// Validates request and kicks off the approval process.
+func (r Account_Internal_Ibm) RequestAccount(requestContainer *datatypes.Container_Account_Internal_Ibm_Request) (err error) {
+	var resp datatypes.Void
+	params := []interface{}{
+		requestContainer,
+	}
+	err = r.Session.DoRequest("SoftLayer_Account_Internal_Ibm", "requestAccount", params, &r.Options, &resp)
 	return
 }
 

--- a/services/hardware.go
+++ b/services/hardware.go
@@ -1678,6 +1678,12 @@ func (r Hardware_Component_Model) GetCompatibleParentComponentModels() (resp []d
 }
 
 // Retrieve
+func (r Hardware_Component_Model) GetFirmwareQuantity() (resp uint, err error) {
+	err = r.Session.DoRequest("SoftLayer_Hardware_Component_Model", "getFirmwareQuantity", nil, &r.Options, &resp)
+	return
+}
+
+// Retrieve
 func (r Hardware_Component_Model) GetFirmwares() (resp []datatypes.Hardware_Component_Firmware, err error) {
 	err = r.Session.DoRequest("SoftLayer_Hardware_Component_Model", "getFirmwares", nil, &r.Options, &resp)
 	return

--- a/services/locale.go
+++ b/services/locale.go
@@ -124,6 +124,12 @@ func (r Locale_Country) Offset(offset int) Locale_Country {
 	return r
 }
 
+// This method is to get the collection of VAT country codes and VAT ID Regexes.
+func (r Locale_Country) GetAllVatCountryCodesAndVatIdRegexes() (resp []datatypes.Container_Collection_Locale_VatCountryCodeAndFormat, err error) {
+	err = r.Session.DoRequest("SoftLayer_Locale_Country", "getAllVatCountryCodesAndVatIdRegexes", nil, &r.Options, &resp)
+	return
+}
+
 // Use this method to retrieve a list of countries and locale information available to the current user.
 func (r Locale_Country) GetAvailableCountries() (resp []datatypes.Locale_Country, err error) {
 	err = r.Session.DoRequest("SoftLayer_Locale_Country", "getAvailableCountries", nil, &r.Options, &resp)

--- a/services/network.go
+++ b/services/network.go
@@ -15042,6 +15042,12 @@ func (r Network_Vlan_Firewall) GetTagReferences() (resp []datatypes.Tag_Referenc
 	return
 }
 
+// Whether this firewall qualifies for High Availability upgrade.
+func (r Network_Vlan_Firewall) IsHighAvailabilityUpgradeAvailable() (resp bool, err error) {
+	err = r.Session.DoRequest("SoftLayer_Network_Vlan_Firewall", "isHighAvailabilityUpgradeAvailable", nil, &r.Options, &resp)
+	return
+}
+
 // Reject a request from technical support to bypass the firewall. Once rejected, IBM support will not be able to route and unroute the VLAN on the firewall.
 func (r Network_Vlan_Firewall) RejectBypassRequest() (err error) {
 	var resp datatypes.Void


### PR DESCRIPTION
I did notice that *Hardware_Component_Revision* was removed (not sure if removal is a bad thing) and that the services/bluepages.go had an issue so didn't check in the bluepages.go files.