### PR TITLE
`make generate` to update datatypes and services

### DIFF
--- a/datatypes/account.go
+++ b/datatypes/account.go
@@ -245,9 +245,6 @@ type Account struct {
 	// Private template group objects (parent and children) and the shared template group objects (parent only) for an account.
 	BlockDeviceTemplateGroups []Virtual_Guest_Block_Device_Template_Group `json:"blockDeviceTemplateGroups,omitempty" xmlrpc:"blockDeviceTemplateGroups,omitempty"`
 
-	// This field is deprecated and should not be used.
-	BlueIdAuthenticationRequiredFlag *bool `json:"blueIdAuthenticationRequiredFlag,omitempty" xmlrpc:"blueIdAuthenticationRequiredFlag,omitempty"`
-
 	// The Bluemix account link associated with this SoftLayer account, if one exists.
 	BluemixAccountLink *Account_Link_Bluemix `json:"bluemixAccountLink,omitempty" xmlrpc:"bluemixAccountLink,omitempty"`
 

--- a/datatypes/container.go
+++ b/datatypes/container.go
@@ -3768,6 +3768,14 @@ type Container_Product_Order_Network_Protection_Firewall_Dedicated struct {
 	VlanId *int `json:"vlanId,omitempty" xmlrpc:"vlanId,omitempty"`
 }
 
+// This is the datatype that needs to be populated and sent to SoftLayer_Product_Order::placeOrder. This datatype has everything required to place an order with SoftLayer.
+type Container_Product_Order_Network_Protection_Firewall_Dedicated_Upgrade struct {
+	Container_Product_Order_Network_Protection_Firewall_Dedicated
+
+	// no documentation yet
+	FirewallId *int `json:"firewallId,omitempty" xmlrpc:"firewallId,omitempty"`
+}
+
 // This is the datatype that needs to be populated and sent to SoftLayer_Product_Order::placeOrder. This datatype has everything required to place an order for Storage as a Service.
 type Container_Product_Order_Network_Storage_AsAService struct {
 	Container_Product_Order

--- a/datatypes/hardware.go
+++ b/datatypes/hardware.go
@@ -24,6 +24,9 @@ package datatypes
 type Hardware struct {
 	Entity
 
+	// Determine if hardware object has Software Guard Extension (SGX) enabled.
+	SGXEnabled *bool `json:"SGXEnabled,omitempty" xmlrpc:"SGXEnabled,omitempty"`
+
 	// The account associated with a piece of hardware.
 	Account *Account `json:"account,omitempty" xmlrpc:"account,omitempty"`
 
@@ -813,6 +816,9 @@ type Hardware_Component struct {
 	// A RAID controllers RAID mode.
 	RaidMode *string `json:"raidMode,omitempty" xmlrpc:"raidMode,omitempty"`
 
+	// The component revision designation.
+	Revision *Hardware_Component_Revision `json:"revision,omitempty" xmlrpc:"revision,omitempty"`
+
 	// The component serial number.
 	SerialNumber *string `json:"serialNumber,omitempty" xmlrpc:"serialNumber,omitempty"`
 
@@ -1391,6 +1397,32 @@ type Hardware_Component_RemoteManagement_User struct {
 
 	// The username used for this remote management command.
 	Username *string `json:"username,omitempty" xmlrpc:"username,omitempty"`
+}
+
+// no documentation yet
+type Hardware_Component_Revision struct {
+	Entity
+
+	// The firmware build date
+	BiosDate *Time `json:"biosDate,omitempty" xmlrpc:"biosDate,omitempty"`
+
+	// The Firmware installed on this record's Hardware Component.
+	Firmware *Hardware_Component_Firmware `json:"firmware,omitempty" xmlrpc:"firmware,omitempty"`
+
+	// no documentation yet
+	FirmwareVersionId *int `json:"firmwareVersionId,omitempty" xmlrpc:"firmwareVersionId,omitempty"`
+
+	// The Hardware Component this revision record applies to.
+	HardwareComponent *Hardware_Component `json:"hardwareComponent,omitempty" xmlrpc:"hardwareComponent,omitempty"`
+
+	// no documentation yet
+	HardwareComponentId *int `json:"hardwareComponentId,omitempty" xmlrpc:"hardwareComponentId,omitempty"`
+
+	// no documentation yet
+	Id *int `json:"id,omitempty" xmlrpc:"id,omitempty"`
+
+	// The firmware revision
+	Revision *string `json:"revision,omitempty" xmlrpc:"revision,omitempty"`
 }
 
 // The SoftLayer_Hardware_Component_SecurityDevice is used to determine the security devices attached to the hardware component.

--- a/datatypes/network.go
+++ b/datatypes/network.go
@@ -2063,6 +2063,9 @@ type Network_LBaaS_HealthMonitor struct {
 	CreateDate *Time `json:"createDate,omitempty" xmlrpc:"createDate,omitempty"`
 
 	// no documentation yet
+	Id *int `json:"id,omitempty" xmlrpc:"id,omitempty"`
+
+	// no documentation yet
 	Interval *int `json:"interval,omitempty" xmlrpc:"interval,omitempty"`
 
 	// no documentation yet
@@ -2099,6 +2102,9 @@ type Network_LBaaS_Listener struct {
 
 	// no documentation yet
 	DefaultPool *Network_LBaaS_Pool `json:"defaultPool,omitempty" xmlrpc:"defaultPool,omitempty"`
+
+	// no documentation yet
+	Id *int `json:"id,omitempty" xmlrpc:"id,omitempty"`
 
 	// Specifies when the listener was updated previously.
 	ModifyDate *Time `json:"modifyDate,omitempty" xmlrpc:"modifyDate,omitempty"`
@@ -2143,6 +2149,9 @@ type Network_LBaaS_LoadBalancer struct {
 
 	// Health monitors for the backend members.
 	HealthMonitors []Network_LBaaS_HealthMonitor `json:"healthMonitors,omitempty" xmlrpc:"healthMonitors,omitempty"`
+
+	// no documentation yet
+	Id *int `json:"id,omitempty" xmlrpc:"id,omitempty"`
 
 	// Specifies if a load balancer is public=1 or private=0.
 	IsPublic *int `json:"isPublic,omitempty" xmlrpc:"isPublic,omitempty"`
@@ -2256,14 +2265,14 @@ type Network_LBaaS_LoadBalancerServerInstanceInfo struct {
 	Weight *int `json:"weight,omitempty" xmlrpc:"weight,omitempty"`
 }
 
-// SoftLayer_Network_LBaaS_LoadBalancerStatistics is a collection of metrics retrieved from a load balancer instance. The available metrics are: <ul> <li>Total number of current sessions</li> <li>Total number of error requests</li> <li>Total number of received packets</li> <li>Total number of transmitted packets</li> <li>Total number of accepted/alive connections</li> <li>Request rate</li> <li>Number of members down</li> <li>NUmber of members up</li> <li>Throughput</li> <li>Connection rate</li> </ul>
+// SoftLayer_Network_LBaaS_LoadBalancerStatistics is a collection of metrics retrieved from a load balancer instance. The available metrics are: <ul> <li>NUmber of members up</li> <li>Number of members down</li> <li>Total number of active connections</li> <li>Throughput</li> <li>Data processed by month</li> <li>Connection rate</li> </ul>
 type Network_LBaaS_LoadBalancerStatistics struct {
 	Entity
 
 	// Number of connections seen at the
 	ConnectionRate *int `json:"connectionRate,omitempty" xmlrpc:"connectionRate,omitempty"`
 
-	// dataProcessedByMonth is the total of bin and bout
+	// Data processed by month is the total of bin and bout
 	DataProcessedByMonth *int `json:"dataProcessedByMonth,omitempty" xmlrpc:"dataProcessedByMonth,omitempty"`
 
 	// Number of members in DOWN health state
@@ -2288,6 +2297,9 @@ type Network_LBaaS_Member struct {
 
 	// Specifies when a load balancers
 	CreateDate *Time `json:"createDate,omitempty" xmlrpc:"createDate,omitempty"`
+
+	// no documentation yet
+	Id *int `json:"id,omitempty" xmlrpc:"id,omitempty"`
 
 	// Specifies when a load balancers
 	ModifyDate *Time `json:"modifyDate,omitempty" xmlrpc:"modifyDate,omitempty"`
@@ -4320,6 +4332,26 @@ type Network_Storage_Iscsi_OS_Type struct {
 	Name *string `json:"name,omitempty" xmlrpc:"name,omitempty"`
 }
 
+// no documentation yet
+type Network_Storage_MassDataMigration_CrossRegion_Country_Xref struct {
+	Entity
+
+	// SoftLayer_Locale_Country Id.
+	Country *Locale_Country `json:"country,omitempty" xmlrpc:"country,omitempty"`
+
+	// no documentation yet
+	CountryId *int `json:"countryId,omitempty" xmlrpc:"countryId,omitempty"`
+
+	// no documentation yet
+	Id *int `json:"id,omitempty" xmlrpc:"id,omitempty"`
+
+	// Location Group ID of CleverSafe cross region.
+	LocationGroup *Location_Group `json:"locationGroup,omitempty" xmlrpc:"locationGroup,omitempty"`
+
+	// no documentation yet
+	LocationGroupId *int `json:"locationGroupId,omitempty" xmlrpc:"locationGroupId,omitempty"`
+}
+
 // The SoftLayer_Network_Storage_MassDataMigration_Request data type contains information on a single Mass Data Migration request. Creation of these requests is limited to SoftLayer customers through the SoftLayer Customer Portal.
 type Network_Storage_MassDataMigration_Request struct {
 	Entity
@@ -4897,9 +4929,6 @@ type Network_Subnet struct {
 
 	// A bitmask in dotted-quad format that is used to separate a subnet's network address from it's host addresses. This performs the same function as the ''cidr'' property, but is expressed in a string format.
 	Netmask *string `json:"netmask,omitempty" xmlrpc:"netmask,omitempty"`
-
-	// A subnet's associated network component.
-	NetworkComponent *Network_Component `json:"networkComponent,omitempty" xmlrpc:"networkComponent,omitempty"`
 
 	// The upstream network component firewall.
 	NetworkComponentFirewall *Network_Component_Firewall `json:"networkComponentFirewall,omitempty" xmlrpc:"networkComponentFirewall,omitempty"`
@@ -5918,6 +5947,9 @@ type Network_Vlan_Firewall struct {
 
 	// no documentation yet
 	TagReferences []Tag_Reference `json:"tagReferences,omitempty" xmlrpc:"tagReferences,omitempty"`
+
+	// A firewall's associated upgrade request object, if any.
+	UpgradeRequest *Product_Upgrade_Request `json:"upgradeRequest,omitempty" xmlrpc:"upgradeRequest,omitempty"`
 }
 
 // A SoftLayer_Network_Component_Firewall_Rule object type represents a currently running firewall rule and contains relative information. Use the [[SoftLayer Network Firewall Update Request]] service to submit a firewall update request. Use the [[SoftLayer Network Firewall Template]] service to pull SoftLayer recommended rule set templates.

--- a/services/account.go
+++ b/services/account.go
@@ -499,12 +499,6 @@ func (r Account) GetBlockDeviceTemplateGroups() (resp []datatypes.Virtual_Guest_
 	return
 }
 
-// Retrieve This field is deprecated and should not be used.
-func (r Account) GetBlueIdAuthenticationRequiredFlag() (resp bool, err error) {
-	err = r.Session.DoRequest("SoftLayer_Account", "getBlueIdAuthenticationRequiredFlag", nil, &r.Options, &resp)
-	return
-}
-
 // Retrieve The Bluemix account link associated with this SoftLayer account, if one exists.
 func (r Account) GetBluemixAccountLink() (resp datatypes.Account_Link_Bluemix, err error) {
 	err = r.Session.DoRequest("SoftLayer_Account", "getBluemixAccountLink", nil, &r.Options, &resp)

--- a/services/hardware.go
+++ b/services/hardware.go
@@ -1256,6 +1256,12 @@ func (r Hardware) GetRouters() (resp []datatypes.Hardware, err error) {
 	return
 }
 
+// Retrieve Determine if hardware object has Software Guard Extension (SGX) enabled.
+func (r Hardware) GetSGXEnabled() (resp bool, err error) {
+	err = r.Session.DoRequest("SoftLayer_Hardware", "getSGXEnabled", nil, &r.Options, &resp)
+	return
+}
+
 // Retrieve Collection of scale assets this hardware corresponds to.
 func (r Hardware) GetScaleAssets() (resp []datatypes.Scale_Asset, err error) {
 	err = r.Session.DoRequest("SoftLayer_Hardware", "getScaleAssets", nil, &r.Options, &resp)
@@ -3122,6 +3128,12 @@ func (r Hardware_Router) GetResourceGroups() (resp []datatypes.Resource_Group, e
 // Retrieve A hardware's routers.
 func (r Hardware_Router) GetRouters() (resp []datatypes.Hardware, err error) {
 	err = r.Session.DoRequest("SoftLayer_Hardware_Router", "getRouters", nil, &r.Options, &resp)
+	return
+}
+
+// Retrieve Determine if hardware object has Software Guard Extension (SGX) enabled.
+func (r Hardware_Router) GetSGXEnabled() (resp bool, err error) {
+	err = r.Session.DoRequest("SoftLayer_Hardware_Router", "getSGXEnabled", nil, &r.Options, &resp)
 	return
 }
 
@@ -5104,6 +5116,12 @@ func (r Hardware_SecurityModule) GetReverseDomainRecords() (resp []datatypes.Dns
 // Retrieve A hardware's routers.
 func (r Hardware_SecurityModule) GetRouters() (resp []datatypes.Hardware, err error) {
 	err = r.Session.DoRequest("SoftLayer_Hardware_SecurityModule", "getRouters", nil, &r.Options, &resp)
+	return
+}
+
+// Retrieve Determine if hardware object has Software Guard Extension (SGX) enabled.
+func (r Hardware_SecurityModule) GetSGXEnabled() (resp bool, err error) {
+	err = r.Session.DoRequest("SoftLayer_Hardware_SecurityModule", "getSGXEnabled", nil, &r.Options, &resp)
 	return
 }
 
@@ -7302,6 +7320,12 @@ func (r Hardware_Server) GetReverseDomainRecords() (resp []datatypes.Dns_Domain,
 // Retrieve A hardware's routers.
 func (r Hardware_Server) GetRouters() (resp []datatypes.Hardware, err error) {
 	err = r.Session.DoRequest("SoftLayer_Hardware_Server", "getRouters", nil, &r.Options, &resp)
+	return
+}
+
+// Retrieve Determine if hardware object has Software Guard Extension (SGX) enabled.
+func (r Hardware_Server) GetSGXEnabled() (resp bool, err error) {
+	err = r.Session.DoRequest("SoftLayer_Hardware_Server", "getSGXEnabled", nil, &r.Options, &resp)
 	return
 }
 

--- a/services/network.go
+++ b/services/network.go
@@ -4644,6 +4644,15 @@ func (r Network_Interconnect_Tenant) GetDatacenterName() (resp string, err error
 }
 
 // no documentation yet
+func (r Network_Interconnect_Tenant) GetDirectLinkSpeeds(offeringType *string) (resp string, err error) {
+	params := []interface{}{
+		offeringType,
+	}
+	err = r.Session.DoRequest("SoftLayer_Network_Interconnect_Tenant", "getDirectLinkSpeeds", params, &r.Options, &resp)
+	return
+}
+
+// no documentation yet
 func (r Network_Interconnect_Tenant) GetNetworkZones() (resp []string, err error) {
 	err = r.Session.DoRequest("SoftLayer_Network_Interconnect_Tenant", "getNetworkZones", nil, &r.Options, &resp)
 	return
@@ -12336,6 +12345,70 @@ func (r Network_Storage_Iscsi_OS_Type) GetObject() (resp datatypes.Network_Stora
 	return
 }
 
+// no documentation yet
+type Network_Storage_MassDataMigration_CrossRegion_Country_Xref struct {
+	Session *session.Session
+	Options sl.Options
+}
+
+// GetNetworkStorageMassDataMigrationCrossRegionCountryXrefService returns an instance of the Network_Storage_MassDataMigration_CrossRegion_Country_Xref SoftLayer service
+func GetNetworkStorageMassDataMigrationCrossRegionCountryXrefService(sess *session.Session) Network_Storage_MassDataMigration_CrossRegion_Country_Xref {
+	return Network_Storage_MassDataMigration_CrossRegion_Country_Xref{Session: sess}
+}
+
+func (r Network_Storage_MassDataMigration_CrossRegion_Country_Xref) Id(id int) Network_Storage_MassDataMigration_CrossRegion_Country_Xref {
+	r.Options.Id = &id
+	return r
+}
+
+func (r Network_Storage_MassDataMigration_CrossRegion_Country_Xref) Mask(mask string) Network_Storage_MassDataMigration_CrossRegion_Country_Xref {
+	if !strings.HasPrefix(mask, "mask[") && (strings.Contains(mask, "[") || strings.Contains(mask, ",")) {
+		mask = fmt.Sprintf("mask[%s]", mask)
+	}
+
+	r.Options.Mask = mask
+	return r
+}
+
+func (r Network_Storage_MassDataMigration_CrossRegion_Country_Xref) Filter(filter string) Network_Storage_MassDataMigration_CrossRegion_Country_Xref {
+	r.Options.Filter = filter
+	return r
+}
+
+func (r Network_Storage_MassDataMigration_CrossRegion_Country_Xref) Limit(limit int) Network_Storage_MassDataMigration_CrossRegion_Country_Xref {
+	r.Options.Limit = &limit
+	return r
+}
+
+func (r Network_Storage_MassDataMigration_CrossRegion_Country_Xref) Offset(offset int) Network_Storage_MassDataMigration_CrossRegion_Country_Xref {
+	r.Options.Offset = &offset
+	return r
+}
+
+// no documentation yet
+func (r Network_Storage_MassDataMigration_CrossRegion_Country_Xref) GetAllObjects() (resp []datatypes.Network_Storage_MassDataMigration_CrossRegion_Country_Xref, err error) {
+	err = r.Session.DoRequest("SoftLayer_Network_Storage_MassDataMigration_CrossRegion_Country_Xref", "getAllObjects", nil, &r.Options, &resp)
+	return
+}
+
+// Retrieve SoftLayer_Locale_Country Id.
+func (r Network_Storage_MassDataMigration_CrossRegion_Country_Xref) GetCountry() (resp datatypes.Locale_Country, err error) {
+	err = r.Session.DoRequest("SoftLayer_Network_Storage_MassDataMigration_CrossRegion_Country_Xref", "getCountry", nil, &r.Options, &resp)
+	return
+}
+
+// Retrieve Location Group ID of CleverSafe cross region.
+func (r Network_Storage_MassDataMigration_CrossRegion_Country_Xref) GetLocationGroup() (resp datatypes.Location_Group, err error) {
+	err = r.Session.DoRequest("SoftLayer_Network_Storage_MassDataMigration_CrossRegion_Country_Xref", "getLocationGroup", nil, &r.Options, &resp)
+	return
+}
+
+// no documentation yet
+func (r Network_Storage_MassDataMigration_CrossRegion_Country_Xref) GetObject() (resp datatypes.Network_Storage_MassDataMigration_CrossRegion_Country_Xref, err error) {
+	err = r.Session.DoRequest("SoftLayer_Network_Storage_MassDataMigration_CrossRegion_Country_Xref", "getObject", nil, &r.Options, &resp)
+	return
+}
+
 // The SoftLayer_Network_Storage_MassDataMigration_Request data type contains information on a single Mass Data Migration request. Creation of these requests is limited to SoftLayer customers through the SoftLayer Customer Portal.
 type Network_Storage_MassDataMigration_Request struct {
 	Session *session.Session
@@ -12460,6 +12533,12 @@ func (r Network_Storage_MassDataMigration_Request) GetModifyUser() (resp datatyp
 // no documentation yet
 func (r Network_Storage_MassDataMigration_Request) GetObject() (resp datatypes.Network_Storage_MassDataMigration_Request, err error) {
 	err = r.Session.DoRequest("SoftLayer_Network_Storage_MassDataMigration_Request", "getObject", nil, &r.Options, &resp)
+	return
+}
+
+// Returns placeholder MDMS requests for any MDMS order pending approval.
+func (r Network_Storage_MassDataMigration_Request) GetPendingRequests() (resp []datatypes.Network_Storage_MassDataMigration_Request, err error) {
+	err = r.Session.DoRequest("SoftLayer_Network_Storage_MassDataMigration_Request", "getPendingRequests", nil, &r.Options, &resp)
 	return
 }
 
@@ -13018,12 +13097,6 @@ func (r Network_Subnet) GetHardware() (resp []datatypes.Hardware, err error) {
 // Retrieve All the ip addresses associated with a subnet.
 func (r Network_Subnet) GetIpAddresses() (resp []datatypes.Network_Subnet_IpAddress, err error) {
 	err = r.Session.DoRequest("SoftLayer_Network_Subnet", "getIpAddresses", nil, &r.Options, &resp)
-	return
-}
-
-// Retrieve A subnet's associated network component.
-func (r Network_Subnet) GetNetworkComponent() (resp datatypes.Network_Component, err error) {
-	err = r.Session.DoRequest("SoftLayer_Network_Subnet", "getNetworkComponent", nil, &r.Options, &resp)
 	return
 }
 
@@ -15039,6 +15112,12 @@ func (r Network_Vlan_Firewall) GetRules() (resp []datatypes.Network_Vlan_Firewal
 // Retrieve
 func (r Network_Vlan_Firewall) GetTagReferences() (resp []datatypes.Tag_Reference, err error) {
 	err = r.Session.DoRequest("SoftLayer_Network_Vlan_Firewall", "getTagReferences", nil, &r.Options, &resp)
+	return
+}
+
+// Retrieve A firewall's associated upgrade request object, if any.
+func (r Network_Vlan_Firewall) GetUpgradeRequest() (resp datatypes.Product_Upgrade_Request, err error) {
+	err = r.Session.DoRequest("SoftLayer_Network_Vlan_Firewall", "getUpgradeRequest", nil, &r.Options, &resp)
 	return
 }
 


### PR DESCRIPTION
services/bluepages.go had an issue during `make` so didn't check
in two bluepages.go files.

I was specifically looking to get the Id added in some of the Network datatypes.