### PR TITLE
Add a check for a rate limit exceeded exception in the response body.

### DIFF
--- a/session/rest.go
+++ b/session/rest.go
@@ -297,10 +297,9 @@ func makeHTTPRequest(
 			// If the error in the response body is in the retry list, set the error code to a retry (599)
 			if e.Exception == retryError {
 				e.StatusCode = 599
-				break
+				return responseBody, resp.StatusCode, e
 			}
 		}
-		return responseBody, resp.StatusCode, e
 	}
 
 	return responseBody, resp.StatusCode, nil


### PR DESCRIPTION
If a rate limit exceeded error is returned in the response body,
add support to enable retries.

Signed-off-by: Craig Yamamoto <craigyam@us.ibm.com>