### PR TITLE
preserve the original sl error

### DIFF
--- a/session/rest.go
+++ b/session/rest.go
@@ -60,6 +60,10 @@ func (r *RestTransport) DoRequest(sess *Session, service string, method string, 
 		options)
 
 	if err != nil {
+		//Preserve the original sl error
+		if _, ok := err.(sl.Error); ok {
+			return err
+		}
 		return sl.Error{Wrapped: err, StatusCode: code}
 	}
 


### PR DESCRIPTION
`makeHTTPRequest` can now directly send the wrapped error in `sl.Error`. When it sends such an error just return that