### PR TITLE
Fix check for billing item immediatley after order creation

### DIFF
--- a/helpers/order/order.go
+++ b/helpers/order/order.go
@@ -20,6 +20,7 @@ import (
 	"github.com/softlayer/softlayer-go/datatypes"
 	"github.com/softlayer/softlayer-go/services"
 	"github.com/softlayer/softlayer-go/session"
+	"github.com/softlayer/softlayer-go/sl"
 )
 
 // CheckBillingOrderStatus returns true if the status of the billing order for
@@ -38,10 +39,13 @@ func CheckBillingOrderStatus(sess *session.Session, receipt *datatypes.Container
 		return false, nil, err
 	}
 
-	currentStatus := *item.BillingItem.ProvisionTransaction.TransactionStatus.Name
-	for _, status := range statuses {
-		if currentStatus == status {
-			return true, &item, nil
+	currentStatus, ok := sl.GrabOk(item, "BillingItem.ProvisionTransaction.TransactionStatus.Name")
+
+	if ok {
+		for _, status := range statuses {
+			if currentStatus == status {
+				return true, &item, nil
+			}
 		}
 	}
 


### PR DESCRIPTION
We were using CheckBillingOrderComplete to check the status of the order. When we place order and check for order we are facing nil pointer exception the billing Item is nil 
```
2018-08-03T10:30:06.200+0530 [DEBUG] plugin.terraform-provider-ibm: 2018/08/03 10:30:06 [DEBUG] Request URL:  GET https://api.softlayer.com/rest/v3/SoftLayer_Billing_Order_Item/356146637.json?objectMask=mask%5Bid%2CbillingItem%5Bid%2CprovisionTransaction%5Bid%2CtransactionStatus%5Bname%5D%5D%5D%5D
2018-08-03T10:30:06.200+0530 [DEBUG] plugin.terraform-provider-ibm: 2018/08/03 10:30:06 [DEBUG] Parameters:
2018-08-03T10:30:07.478+0530 [DEBUG] plugin.terraform-provider-ibm: 2018/08/03 10:30:07 [DEBUG] Status Code:  200
2018-08-03T10:30:07.478+0530 [DEBUG] plugin.terraform-provider-ibm: 2018/08/03 10:30:07 [DEBUG] Response:  {"id":356146637}
2018-08-03T10:30:07.480+0530 [DEBUG] plugin.terraform-provider-ibm: 
Error: Error applying plan:

1 error(s) occurred:

* ibm_object_storage_account.testacc_foobar: 1 error(s) occurred:

* ibm_object_storage_account.testacc_foobar: unexpected EOF

Terraform does not automatically rollback in the face of errors.
Instead, your Terraform state file has been partially updated with
any resources that successfully completed. Please address the error
above and apply again to incrementally change your infrastructure.


panic: runtime error: invalid memory address or nil pointer dereference
2018-08-03T10:30:07.480+0530 [DEBUG] plugin.terraform-provider-ibm: [signal SIGSEGV: segmentation violation code=0x1 addr=0x438 pc=0x1a3ab2c]
2018-08-03T10:30:07.480+0530 [DEBUG] plugin.terraform-provider-ibm: 
2018-08-03T10:30:07.481+0530 [DEBUG] plugin.terraform-provider-ibm: goroutine 97 [running]:
2018-08-03T10:30:07.481+0530 [DEBUG] plugin.terraform-provider-ibm: github.com/terraform-providers/terraform-provider-ibm/vendor/github.com/softlayer/softlayer-go/helpers/order.CheckBillingOrderStatus(0xc42048a240, 0xc4201c2780, 0xc420077c80, 0x1, 0x1, 0x2032620, 0xc42000e2f8, 0x0, 0x0)
2018-08-03T10:30:07.481+0530 [DEBUG] plugin.terraform-provider-ibm: 	/Users/hkantare/app/src/github.com/terraform-providers/terraform-provider-ibm/vendor/github.com/softlayer/softlayer-go/helpers/order/order.go:41 +0x2cc
```
On subsequent request the billingItem is present.