### PR TITLE
add feature about login with IAMtoken

### DIFF
--- a/session/rest.go
+++ b/session/rest.go
@@ -232,10 +232,13 @@ func makeHTTPRequest(
 		return nil, 0, err
 	}
 
-	if session.APIKey != "" {
+	switch {
+	case session.APIKey != "":
 		req.SetBasicAuth(session.UserName, session.APIKey)
-	} else if session.AuthToken != "" {
+	case session.AuthToken != "":
 		req.SetBasicAuth(fmt.Sprintf("%d", session.UserId), session.AuthToken)
+	case session.IAMToken != "":
+		req.Header.Set("Authorization", session.IAMToken)
 	}
 
 	// For cases where session is built from the raw structure and not using New() , the UserAgent would be empty

--- a/session/session.go
+++ b/session/session.go
@@ -100,6 +100,9 @@ type Session struct {
 	// UserId is the user id for token-based authentication
 	UserId int
 
+	//IAMToken is the IAM token secret that included IMS account for token-based authentication
+	IAMToken string
+
 	// AuthToken is the token secret for token-based authentication
 	AuthToken string
 


### PR DESCRIPTION
Softlayer support auth with IAM token .
https://github.ibm.com/ibmcloud/platform-unification/blob/tri-api-key-001/architecture/user-access/api-key.md
```
curl -X GET https://api.softlayer.com/mobile/v3.1/SoftLayer_Account/getOpenTickets.json  -H "Authorization: $token" | jq .
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  6806  100  6806    0     0   4318      0  0:00:01  0:00:01 --:--:--  4315
[
  {
    "accountId": 27**4,
    "assignedUserId": 644**5,
    "billableFlag": null,
    "changeOwnerFlag": false,
    "createDate": "2018-08-26T22:16:18-07:00",
    "euSupportedLocationId": null,
    "groupId": 1246,
    "id": 64281087,
    "lastEditDate": "2018-09-11T07:45:15-07:00",
    "lastEditType": "EMPLOYEE",
    "lastResponseDate": "2018-09-07T03:56:27-07:00",
    "locationId": null,
    "modifyDate": "2018-09-11T07:45:15-07:00",
    "notifyUserOnUpdateFlag": false,
    "originatingIpAddress": "158.**88",
    "priority": 3,
    "responsibleBrandId": 1,
    "serverAdministrationBillingAmount": null,
    "serverAdministrationBillingInvoiceId": null,
    "serverAdministrationFlag": 0,
    "serverAdministrationRefundInvoiceId": null,
    "serviceProviderId": 1,
    "serviceProviderResourceId": "64281087",
    "statusId": 1001,
    "subjectId": 1061,
    "title": "Private Network Question -***6",
    "totalUpdateCount": 65,
    "userEditableFlag": true,
    "status": {
      "id": 1001,
      "name": "Open"
    }
  },
  ...
]

```