### PR TITLE
Custom context.Context for REST client

### DIFF
--- a/session/rest.go
+++ b/session/rest.go
@@ -261,6 +261,11 @@ func makeHTTPRequest(
 		log.Println("[DEBUG] Parameters: ", requestBody.String())
 	}
 
+	// Apply custom context.Context, if supplied
+	if session.Context != nil {
+		req = req.WithContext(session.Context)
+	}
+
 	resp, err := client.Do(req)
 	if err != nil {
 		statusCode := 520

--- a/session/session.go
+++ b/session/session.go
@@ -17,6 +17,7 @@
 package session
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"math/rand"
@@ -117,6 +118,9 @@ type Session struct {
 
 	// HTTPClient This allows a custom user configured HTTP Client.
 	HTTPClient *http.Client
+
+	// Context allows a custom context.Context for outbound HTTP requests
+	Context context.Context
 
 	// Custom Headers to be used on each request (Currently only for rest)
 	Headers map[string]string


### PR DESCRIPTION
@renier As discussed, here is an outline for allowing the client code to specify the context.Context used for a Session ... albeit only for REST requests at this time. Is this something that can be applied to the XMLRPC client too?