### PR TITLE
Added PlaceQuote to phraseMethodArg

### DIFF
--- a/services/billing.go
+++ b/services/billing.go
@@ -2405,7 +2405,7 @@ func (r Billing_Order_Cart) PlaceOrder(orderData interface{}) (resp datatypes.Co
 }
 
 // Use this method for placing server quotes and additional services quotes. The same applies for this as with verifyOrder. Send in the SoftLayer_Container_Product_Order_Hardware_Server for server quotes. In addition to verifying the quote, placeQuote() also makes an initial authorization on the SoftLayer_Account tied to this order, if a credit card is on file. If the account tied to this order is a paypal customer, an URL will also be returned to the customer. After placing the order, you must go to this URL to finish the authorization process. This tells paypal that you indeed want to place the order. After going to this URL, it will direct you back to a SoftLayer webpage that tells us you have finished the process.
-func (r Billing_Order_Cart) PlaceQuote(orderData *datatypes.Container_Product_Order) (resp datatypes.Container_Product_Order, err error) {
+func (r Billing_Order_Cart) PlaceQuote(orderData interface{}) (resp datatypes.Container_Product_Order, err error) {
 	params := []interface{}{
 		orderData,
 	}
@@ -2763,7 +2763,7 @@ func (r Billing_Order_Quote) PlaceOrder(orderData interface{}) (resp datatypes.C
 }
 
 // Use this method for placing server quotes and additional services quotes. The same applies for this as with verifyOrder. Send in the SoftLayer_Container_Product_Order_Hardware_Server for server quotes. In addition to verifying the quote, placeQuote() also makes an initial authorization on the SoftLayer_Account tied to this order, if a credit card is on file. If the account tied to this order is a paypal customer, an URL will also be returned to the customer. After placing the order, you must go to this URL to finish the authorization process. This tells paypal that you indeed want to place the order. After going to this URL, it will direct you back to a SoftLayer webpage that tells us you have finished the process.
-func (r Billing_Order_Quote) PlaceQuote(orderData *datatypes.Container_Product_Order) (resp datatypes.Container_Product_Order, err error) {
+func (r Billing_Order_Quote) PlaceQuote(orderData interface{}) (resp datatypes.Container_Product_Order, err error) {
 	params := []interface{}{
 		orderData,
 	}

--- a/services/product.go
+++ b/services/product.go
@@ -1128,7 +1128,7 @@ func (r Product_Order) PlaceOrder(orderData interface{}, saveAsQuote *bool) (res
 }
 
 // Use this method for placing server quotes and additional services quotes. The same applies for this as with verifyOrder. Send in the SoftLayer_Container_Product_Order_Hardware_Server for server quotes. After placing the quote, you must go to this URL to finish the order process. After going to this URL, it will direct you back to a SoftLayer webpage that tells us you have finished the process. After this, it will go to sales for final approval.
-func (r Product_Order) PlaceQuote(orderData *datatypes.Container_Product_Order) (resp datatypes.Container_Product_Order_Receipt, err error) {
+func (r Product_Order) PlaceQuote(orderData interface{}) (resp datatypes.Container_Product_Order_Receipt, err error) {
 	params := []interface{}{
 		orderData,
 	}

--- a/tests/specialcase_test.go
+++ b/tests/specialcase_test.go
@@ -17,11 +17,10 @@
 package tests
 
 import (
-	"testing"
-
 	"github.com/softlayer/softlayer-go/datatypes"
 	"github.com/softlayer/softlayer-go/services"
 	"reflect"
+	"testing"
 )
 
 // Tests for each service/method that follows special case logic during code
@@ -67,17 +66,20 @@ func TestPlaceOrder(t *testing.T) {
 		services.Product_Order{},
 	}
 
+	methods := []string{"PlaceOrder", "VerifyOrder", "PlaceQuote"}
 	for _, service := range services {
 		serviceType := reflect.TypeOf(service)
-		method, _ := serviceType.MethodByName("PlaceOrder")
-		argType := method.Type.In(1).String()
-
-		if argType != "interface {}" {
-			t.Errorf(
-				"Expect %s.PlaceOrder() to accept interface {} as parameter, but %s found instead",
-				serviceType.String(),
-				argType,
-			)
+		for _, methodName := range methods {
+			method, _ := serviceType.MethodByName(methodName)
+			argType := method.Type.In(1).String()
+			if argType != "interface {}" {
+				t.Errorf(
+					"Expect %s.%s() to accept interface {} as parameter, but %s found instead",
+					serviceType.String(),
+					methodName,
+					argType,
+				)
+			}
 		}
 	}
 }

--- a/tools/loadmeta.go
+++ b/tools/loadmeta.go
@@ -413,7 +413,7 @@ func phraseMethodArg(methodName string, argName string, isArray bool, argType st
 	argName = RemoveReservedWords(argName)
 
 	// Handle special case - placeOrder/verifyOrder should take any kind of order type.
-	if (methodName == "placeOrder" || methodName == "verifyOrder") &&
+	if (methodName == "placeOrder" || methodName == "verifyOrder" || methodName == "placeQuote") &&
 		strings.HasPrefix(argType, "SoftLayer_Container_Product_Order") {
 		return fmt.Sprintf("%s interface{}, ", argName)
 	}


### PR DESCRIPTION
#134 

Running `go make generate` adds in a few new services, which I wasn't sure if I should add in this pull request too, so I left them out.

```
examples/testPlaceQuote.go:98:42: cannot use &orderTemplate (type *datatypes.Container_Product_Order_Virtual_Guest) as type *datatypes.Container_Product_Order in argument to orderService.PlaceQuote
```