### PR TITLE
Fix bug where request body is lost on retry

### DIFF
--- a/session/rest.go
+++ b/session/rest.go
@@ -56,7 +56,7 @@ func (r *RestTransport) DoRequest(sess *Session, service string, method string, 
 		sess,
 		path,
 		restMethod,
-		bytes.NewBuffer(parameters),
+		parameters,
 		options)
 
 	if err != nil {
@@ -167,7 +167,7 @@ func encodeQuery(opts *sl.Options) string {
 
 func sendHTTPRequest(
 	sess *Session, path string, requestType string,
-	requestBody *bytes.Buffer, options *sl.Options) ([]byte, int, error) {
+	requestBody []byte, options *sl.Options) ([]byte, int, error) {
 
 	retries := sess.Retries
 	if retries < 2 {
@@ -184,7 +184,7 @@ func sendHTTPRequest(
 
 func tryHTTPRequest(
 	retries int, wait time.Duration, sess *Session,
-	path string, requestType string, requestBody *bytes.Buffer,
+	path string, requestType string, requestBody []byte,
 	options *sl.Options) ([]byte, int, error) {
 
 	resp, code, err := makeHTTPRequest(sess, path, requestType, requestBody, options)
@@ -207,7 +207,7 @@ func tryHTTPRequest(
 
 func makeHTTPRequest(
 	session *Session, path string, requestType string,
-	requestBody *bytes.Buffer, options *sl.Options) ([]byte, int, error) {
+	requestBody []byte, options *sl.Options) ([]byte, int, error) {
 	log := Logger
 
 	client := session.HTTPClient
@@ -227,7 +227,7 @@ func makeHTTPRequest(
 		url = url + session.Endpoint
 	}
 	url = fmt.Sprintf("%s/%s", strings.TrimRight(url, "/"), path)
-	req, err := http.NewRequest(requestType, url, requestBody)
+	req, err := http.NewRequest(requestType, url, bytes.NewBuffer(requestBody))
 	if err != nil {
 		return nil, 0, err
 	}
@@ -258,7 +258,7 @@ func makeHTTPRequest(
 
 	if session.Debug {
 		log.Println("[DEBUG] Request URL: ", requestType, req.URL)
-		log.Println("[DEBUG] Parameters: ", requestBody.String())
+		log.Println("[DEBUG] Parameters: ", string(requestBody))
 	}
 
 	// Apply custom context.Context, if supplied


### PR DESCRIPTION
The retry logic in `tryHTTPRequest` would loose the body (if there was one) since it would be consumed by `client.Do`. On subsequent tries, the body would be empty. This is because the body is being held as a `*bytes.Buffer` (pointer).

This pr moves the conversion of the request body (from `[]byte` to `*bytes.Buffer`) to right before making the http request; therefore, the body is preserved in the `[]byte` for retries.