### PR TITLE
#100 fixed how the xmlrpc transport handled object masks.

### DIFF
--- a/session/xmlrpc.go
+++ b/session/xmlrpc.go
@@ -126,14 +126,12 @@ func (x *XmlRpcTransport) DoRequest(
 	}
 
 	mask := options.Mask
+
 	if mask != "" {
-		if !strings.HasPrefix(mask, "mask[") && !strings.Contains(mask, ";") && strings.Contains(mask, ",") {
+		if !strings.HasPrefix(mask, "mask[")  {
 			mask = fmt.Sprintf("mask[%s]", mask)
-			headers["SoftLayer_ObjectMask"] = map[string]string{"mask": mask}
-		} else {
-			headers[fmt.Sprintf("%sObjectMask", service)] =
-				map[string]interface{}{"mask": genXMLMask(mask)}
-		}
+		} 
+		headers["SoftLayer_ObjectMask"] = map[string]string{"mask":mask}
 	}
 
 	if options.Filter != "" {

--- a/session/xmlrpc_test.go
+++ b/session/xmlrpc_test.go
@@ -20,7 +20,10 @@ import (
 	"testing"
 
 	"fmt"
+	"io/ioutil"
+	"net/http"
 	"reflect"
+	"strings"
 
 	"github.com/jarcoal/httpmock"
 	"github.com/softlayer/softlayer-go/sl"
@@ -76,7 +79,28 @@ var xmltestcases = []xmltestcase{
 		expected:    100,
 		expectError: false,
 	},
+	{
+		description: "Test Object Mask mask[]",
+		service:     "SoftLayer_Account",
+		method:      "getVirtualGuests",
+		args:        nil,
+		options:     sl.Options{Mask: "mask[id,hostname]"},
+		responder:   responderCheckObjectMask,
+		expected:    "OK",
+		expectError: false,		
+	},
+	{
+		description: "Test Object Mask no mask[]",
+		service:     "SoftLayer_Account",
+		method:      "getVirtualGuests",
+		args:        nil,
+		options:     sl.Options{Mask: "id,hostname"},
+		responder:   responderCheckObjectMask,
+		expected:    "OK",
+		expectError: false,		
+	},
 }
+
 
 func TestXmlRpc(t *testing.T) {
 	// The structure for this test is inspired heavily from here:
@@ -148,6 +172,21 @@ func TestXmlRpc(t *testing.T) {
 		teardownxml()
 	}
 }
+
+
+
+func responderCheckObjectMask(req *http.Request) (*http.Response, error) {
+	body, _ := ioutil.ReadAll(req.Body)
+	string_body := string(body)
+	// fmt.Printf("Body: %v\n", string_body)
+	message := "FAILED"
+	if strings.Contains(string_body, "<name>mask</name><value><string>mask[id,hostname]</string>") {
+		message = "OK"
+	}
+
+	resp := httpmock.NewStringResponse(200, `<?xml version="1.0" encoding="utf-8"?><params><param><value>` + message + `</value></param></params>`)
+	return resp, nil
+}	
 
 func setupxml(tc xmltestcase) {
 	httpmock.RegisterResponder(


### PR DESCRIPTION
The xml transport was creating object masks like this, which the API doesn't process properly.
```xml
<member>
     <name>SoftLayer_Product_PackageObjectMask</name>
     <value>
          <struct>
               <member>
                    <name>mask</name>
                    <value>
                         <struct>
                              <member>
                                   <name>itemCategory</name>
                                   <value>
                                        <array>
                                             <data></data>
                                        </array>
                                   </value>
                              </member>
                         </struct>
                    </value>
               </member>
          </struct>
     </value>
</member>
```


Now they should look like this. Similar to how the softlayer-python xml transport produces object masks.

```xml
<member>
     <name>SoftLayer_Product_PackageObjectMask</name>
     <value>
          <struct>
               <member>
                    <name>mask</name>
                    <value><string>mask[id,itemCategory]</string></value>
               </member>
          </struct>
    </value>
</member>
```